### PR TITLE
Override some Element theme defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes to the UKHPI app by version and date
 
+## 1.5.5 - 2020-09-22 (Ian)
+
+- Fix WCAG colour contrast issue, and improve visual consistency by
+  picking dark blue as the primary action colour
+
 ## 1.5.4 - 2020-09-22 (Ian)
 
 - added skip-to-main-content link

--- a/app/assets/stylesheets/_data-view-download.scss
+++ b/app/assets/stylesheets/_data-view-download.scss
@@ -13,12 +13,14 @@
     text-decoration: none;
   }
 
-  &__button, &__button:visited, &__button:link {
+  &__button, &__button:visited, &__button:link, &__button:focus, &__button:link:focus {
     color: white;
+    background-color: $dark-blue;
   }
 }
 
 .c-compare__download-link {
   @extend .button;
+  background-color: $dark-blue;
   font-size: 1.5rem;
 }

--- a/app/assets/stylesheets/_element-rails.scss
+++ b/app/assets/stylesheets/_element-rails.scss
@@ -23,3 +23,35 @@
   word-break: normal;
   -ms-word-break: normal;
 }
+
+.el-button--default {
+  background-color: $grey-8;
+}
+
+.el-button--primary {
+  background-color: $dark-blue;
+}
+
+.el-date-editor {
+  color: $black;
+}
+
+table.el-month-table {
+  td .cell {
+    color: $black;
+  }
+
+  td.current .cell {
+    color: $black;
+    background-color: $yellow-50;
+  }
+
+  td.current .cell:not(.disabled) {
+    color: $black;
+  }
+}
+
+.el-select-dropdown__item.selected {
+  background-color: $dark-blue;
+  color: white;
+}

--- a/app/assets/stylesheets/_gov_uk.scss
+++ b/app/assets/stylesheets/_gov_uk.scss
@@ -18,6 +18,7 @@
 @import "elements/helpers";                       // Helper functions and classes
 
 $grey-8: #f0f0f0;
+$dark-blue: #003078;
 @import "elements/govuk-template-base";                       // HTML elements, set by the GOV.UK template
 
 

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,6 +3,6 @@
 module Version
   MAJOR = '1'
   MINOR = '5'
-  REVISION = '4'
+  REVISION = '5'
   VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}"
 end


### PR DESCRIPTION
To resolve the WCAG compliance issue reported in #259, and achieve
improved visual coherence, this commit overrides some of the Element UI
theme defaults to improve contrast, and uses dark-blue over green for
primary actions.
