### PR TITLE
Put Welsh language selector behind feature flag

### DIFF
--- a/app/views/common/_footer.html.haml
+++ b/app/views/common/_footer.html.haml
@@ -15,6 +15,8 @@
           %li.u-print-hidden
             %a{:href => "https://www.gov.uk/land-registry-public-data"}
               = t('common.footer.public_data')
+          %li.u-print-hidden
+            = link_to('Accessibility', "#{Rails.application.config.relative_url_root || '/'}doc/accessibility")
         .ogl.open-government-licence
           %p.logo.u-print-hidden
             %a{:href => "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3", rel:"license"}

--- a/app/views/common/_header.html.haml
+++ b/app/views/common/_header.html.haml
@@ -31,13 +31,14 @@
 
 .container.o-container
   .o-secondary-banner
-    %nav.o-secondary-banner__lang-select{ 'aria-label' => 'language selector' }
-      - if @view_state.user_selections.english?
-        English
-      - else
-        = link_to('English', @view_state.user_selections.alternative_language_params.params)
-      |
-      - if @view_state.user_selections.welsh?
-        Cymraeg
-      - else
-        = link_to('Cymraeg', @view_state.user_selections.alternative_language_params.params)
+    - if Rails.application.config.welsh_language_enabled
+      %nav.o-secondary-banner__lang-select{ 'aria-label' => 'language selector' }
+        - if @view_state.user_selections.english?
+          English
+        - else
+          = link_to('English', @view_state.user_selections.alternative_language_params.params)
+        |
+        - if @view_state.user_selections.welsh?
+          Cymraeg
+        - else
+          = link_to('Cymraeg', @view_state.user_selections.alternative_language_params.params)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,4 +43,7 @@ Rails.application.configure do
   # API location can be specified in the environment
   # But defaults to the dev service
   config.api_service_url = ENV['API_SERVICE_URL'] || 'http://localhost:8080/dsapi'
+
+  # feature flag for showing the Welsh language switch affordance
+  config.welsh_language_enabled = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,4 +91,7 @@ Rails.application.configure do
   # API location can be specified in the environment
   # But defaults to the dev service
   config.api_service_url = ENV['API_SERVICE_URL'] || 'http://localhost:8080/dsapi'
+
+  # feature flag for showing the Welsh language switch affordance
+  config.welsh_language_enabled = ENV['DEPLOYMENT_ENVIRONMENT'] == 'dev'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,4 +45,7 @@ Rails.application.configure do
   # API location can be specified in the environment
   # But defaults to the dev service
   config.api_service_url = ENV['API_SERVICE_URL'] || 'http://localhost:8080/dsapi'
+
+  # feature flag for showing the Welsh language switch affordance
+  config.welsh_language_enabled = true
 end


### PR DESCRIPTION
In order to ensure that we don't accidentally expose the Welsh language
version before it is ready, this commit puts the Welsh language selector
behind a feature flag. This flag is currently tied to the dev
environment.
