### PR TITLE
Fix Sentry issue `$t not defined`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changes to the UKHPI app by version and date
 
+## 1.5.7 - 2020-09-24 (Ian)
+
+- Fix problem `$t is not defined`, GH-263
+
+## 1.5.6 - 2020-09-23 (Ian)
+
+- Added accessibility statement
+
 ## 1.5.5 - 2020-09-22 (Ian)
 
 - Fix WCAG colour contrast issue, and improve visual consistency by

--- a/app/javascript/components/data-view-dates.vue
+++ b/app/javascript/components/data-view-dates.vue
@@ -108,7 +108,7 @@ export default {
 
     onSaveChanges() {
       if (Moment(this.newToDate).isBefore(Moment(this.newFromDate))) {
-        this.validationMessage = $t('js.compare.validation_dates');
+        this.validationMessage = this.$t('js.compare.validation_dates');
       } else {
         const from = Moment(this.newFromDate).format('YYYY-MM-DD');
         const to = Moment(this.newToDate).format('YYYY-MM-DD');

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,6 +3,6 @@
 module Version
   MAJOR = '1'
   MINOR = '5'
-  REVISION = '5'
+  REVISION = '7'
   VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}"
 end


### PR DESCRIPTION
Fix for missing `this.` when referencing I18n translation from
JavaScript.

Also retrospectively added changelog entry for accessibility statement,
which was accidentally omitted.
