### PR TITLE
Fix 500 error when rendering not-understood resp.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes to the UKHPI app by version and date
 
+## 1.5.17 - 2021-05-04
+
+- (Ian) Fix for GH-15: error 500 instead of HTTP 400 when user chooses
+  a non-recognised location
+
 ## 1.5.16 - 2021-04-27
 
 - (Ian) Updated correction to email address (GH-3)

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -10,7 +10,7 @@ class BrowseController < ApplicationController # rubocop:disable Metrics/ClassLe
     user_selections = UserSelections.new(params)
 
     if !user_selections.valid?
-      render_bad_request
+      render_bad_request(user_selections)
     elsif explain_non_json?(user_selections)
       redirect_to_html_view(user_selections)
     else
@@ -128,8 +128,10 @@ class BrowseController < ApplicationController # rubocop:disable Metrics/ClassLe
     }.merge(new_params))
   end
 
-  def render_bad_request # rubocop:disable Metrics/MethodLength
+  def render_bad_request(user_selections) # rubocop:disable Metrics/MethodLength
     respond_to do |format|
+      @view_state = OpenStruct.new(user_selections: user_selections)
+
       format.html do
         render 'exceptions/error_page',
                locals: { status: 400, sentry_code: nil },

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,6 +3,6 @@
 module Version
   MAJOR = 1
   MINOR = 5
-  REVISION = 16
+  REVISION = 17
   VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}"
 end

--- a/app/views/exceptions/error_page.html.haml
+++ b/app/views/exceptions/error_page.html.haml
@@ -7,6 +7,15 @@
       message as a result of using the HPI or PPD applications, please let us
       know so that we can correct the problem.
 
+    - if @view_state.user_selections&.errors
+      %p
+        The following issues were identified in your request:
+
+      %ul.list.list-bullet
+        - @view_state.user_selections.errors.each do |err_msg|
+          %li
+            = err_msg
+
   - elsif status == 404
     %h1.o-heading--1 Page not found
 


### PR DESCRIPTION
epimorphics/hmlr-linked-data#15
This PR fixes a recently identified problem in UKHPI: if the user
changes the URL parameters so that the location is not recognised, it
should return a 400 error. Instead, the app was failing because there
was no `user_selections` object from which to determine the current
language.

This fix:

- adds the `@view_state` to the error page renderer, so that language
  selection will work correctly
- also lists URL validation errors that have been identified
