### PR TITLE
Add Prometheus metrics for UKHPI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,12 +29,13 @@ gem 'sentry-raven'
 
 gem 'faraday'
 gem 'faraday_middleware'
+gem "get_process_mem", "~> 0.2.7"
 gem 'http_accept_language'
+gem "prometheus-client", "~> 4.0"
 gem 'puma'
+gem 'rdf-turtle'
 gem 'rubocop-rails'
 gem 'yajl-ruby', require: 'yajl'
-
-gem 'rdf-turtle'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,8 @@ GEM
     ffi (1.15.5)
     font-awesome-rails (4.7.0.8)
       railties (>= 3.2, < 8.0)
+    get_process_mem (0.2.7)
+      ffi (~> 1.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
     govuk_elements_rails (3.1.3)
@@ -201,6 +203,7 @@ GEM
     parallel (1.22.1)
     parser (3.1.1.0)
       ast (~> 2.4.1)
+    prometheus-client (4.0.0)
     public_suffix (4.0.6)
     puma (5.6.4)
       nio4r (~> 2.0)
@@ -364,6 +367,7 @@ DEPENDENCIES
   faraday
   faraday_middleware
   font-awesome-rails
+  get_process_mem (~> 0.2.7)
   govuk_elements_rails
   govuk_frontend_toolkit (~> 7.0)
   govuk_template
@@ -379,6 +383,7 @@ DEPENDENCIES
   mocha
   nokogiri
   oj
+  prometheus-client (~> 4.0)
   puma
   rails (~> 6.0)
   rdf-turtle

--- a/app/subscribers/action_dispatch_prometheus_subscriber.rb
+++ b/app/subscribers/action_dispatch_prometheus_subscriber.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Subscribe to :action_dispatch events
+class ActionDispatchPrometheusSubscriber < ActiveSupport::Subscriber
+  attach_to :action_dispatch
+
+  def request(_event)
+    mem = GetProcessMem.new
+
+    Prometheus::Client.registry
+                      .get(:memory_used_mb)
+                      .set(mem.mb)
+  end
+end

--- a/app/subscribers/api_prometheus_subscriber.rb
+++ b/app/subscribers/api_prometheus_subscriber.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Subscribe to :api events
+class ApiPrometheusSubscriber < ActiveSupport::Subscriber
+  attach_to :api
+
+  def response(event) # rubocop:disable Metrics/MethodLength
+    response = event.payload[:response]
+    duration = event.payload[:duration]
+
+    Prometheus::Client.registry
+                      .get(:api_status)
+                      .increment(labels: { status: response.status.to_s })
+    Prometheus::Client.registry
+                      .get(:api_requests)
+                      .increment(labels: { result: 'success' })
+    Prometheus::Client.registry
+                      .get(:api_response_times)
+                      .observe(duration)
+  end
+
+  def connection_failure(event)
+    message = event.payload[:exception]
+    Prometheus::Client.registry
+                      .get(:api_requests)
+                      .increment(labels: { result: 'failure' })
+    Prometheus::Client.registry
+                      .get(:api_connection_failure)
+                      .increment(labels: { message: message.to_s })
+  end
+
+  def service_exception(event)
+    message = event.payload[:exception]
+    Prometheus::Client.registry
+                      .get(:api_service_exception)
+                      .increment(labels: { message: message.to_s })
+  end
+end

--- a/app/subscribers/application_prometheus_subscriber.rb
+++ b/app/subscribers/application_prometheus_subscriber.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Subscribe to :application events
+class ApplicationPrometheusSubscriber < ActiveSupport::Subscriber
+  attach_to :application
+
+  def internal_error(event)
+    message = event.payload[:exception]
+    Prometheus::Client.registry
+                      .get(:internal_application_error)
+                      .increment(labels: { message: message.to_s })
+  end
+end

--- a/config.ru
+++ b/config.ru
@@ -3,4 +3,10 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('config/environment', __dir__)
+require 'prometheus/middleware/collector'
+require 'prometheus/middleware/exporter'
+
+use Prometheus::Middleware::Collector
+use Prometheus::Middleware::Exporter
+
 run Rails.application

--- a/config/initializers/load_notification_subscribers.rb
+++ b/config/initializers/load_notification_subscribers.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Dir[Rails.root.join('app/subscribers/**/*_subscriber.rb')].sort.each do |source|
+  require source
+end

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+prometheus = Prometheus::Client.registry
+
+# Prometheus counters
+prometheus.counter(
+  :api_status,
+  docstring: 'Response from back-end API',
+  labels: [:status]
+)
+prometheus.counter(
+  :api_requests,
+  docstring: 'Overall count of back-end API requests',
+  labels: [:result]
+)
+prometheus.counter(
+  :api_connection_failure,
+  docstring: 'Reasons for back-end API connection failure',
+  labels: [:message]
+)
+prometheus.counter(
+  :api_service_exception,
+  docstring: 'The response from the back-end data API was not processed',
+  labels: [:message]
+)
+prometheus.counter(
+  :internal_application_error,
+  docstring: 'Unexpected events and internal error count',
+  labels: [:message]
+)
+
+# Prometheus gauges
+prometheus.gauge(
+  :memory_used_mb,
+  docstring: 'Process memory usage in mb'
+)
+
+# Prometheus histograms
+prometheus.histogram(
+  :api_response_times,
+  docstring: 'Histogram of response times for API requests',
+  buckets: Prometheus::Client::Histogram.exponential_buckets(start: 0.005, count: 16)
+)


### PR DESCRIPTION
This commit adds the standard Prometheus metrics that are built in to
the Ruby Prometheus client, and adds API and memory usage, per local
best practice.

This version uses the `prometheus-client` 4.0 release, which includes an
metrics registry and helper methods, so we can dispense with our own
local Prometheus registry.
