### PR TITLE
Update to the latest version Sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,16 +25,16 @@ gem 'govuk_elements_rails'
 gem 'govuk_frontend_toolkit', '~> 7.0'
 gem 'govuk_template'
 gem 'js-routes', '< 2.0'
-gem 'sentry-raven'
 
 gem 'faraday'
 gem 'faraday_middleware'
-gem "get_process_mem", "~> 0.2.7"
+gem 'get_process_mem', '~> 0.2.7'
 gem 'http_accept_language'
-gem "prometheus-client", "~> 4.0"
+gem 'prometheus-client', '~> 4.0'
 gem 'puma'
 gem 'rdf-turtle'
 gem 'rubocop-rails'
+gem 'sentry-rails', '~> 5.2'
 gem 'yajl-ruby', require: 'yajl'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -294,8 +294,11 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
     semantic_range (3.0.0)
-    sentry-raven (3.1.2)
-      faraday (>= 1.0)
+    sentry-rails (5.2.1)
+      railties (>= 5.0)
+      sentry-ruby-core (~> 5.2.1)
+    sentry-ruby-core (5.2.1)
+      concurrent-ruby
     sexp_processor (4.16.0)
     simplecov (0.21.2)
       docile (~> 1.1)
@@ -391,7 +394,7 @@ DEPENDENCIES
   rubocop-rails
   sass-rails
   selenium-webdriver
-  sentry-raven
+  sentry-rails (~> 5.2)
   simplecov
   spring
   tzinfo-data

--- a/README.md
+++ b/README.md
@@ -347,3 +347,4 @@ of the application:
 | -------------------------- | -------------------------------------------------------------------- | ----------------------- |
 | `RAILS_RELATIVE_URL_ROOT`  | The path from the server root to the application                     | `/app/ukhpi`            |
 | `API_SERVICE_URL`          | The base URL from which data is accessed, including the HTTP scheme  | `http://localhost:8080` |
+| `SENTRY_API_KEY`           | The DSN for reporting errors and other events to Sentry              |                         |

--- a/app/controllers/exceptions_controller.rb
+++ b/app/controllers/exceptions_controller.rb
@@ -22,7 +22,7 @@ class ExceptionsController < ApplicationController
   def maybe_report_to_sentry(exception, status_code)
     return nil unless status_code >= 500
 
-    Raven.capture_exception(exception)
-    Raven.last_event_id
+    sevent = Sentry.capture_exception(exception)
+    sevent.event_id
   end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,12 +1,14 @@
 # frozen-string-literal: true
 
 Rails.application.reloader.to_prepare do
-  Raven.configure do |config|
-    config.dsn = 'https://1150348b449a444bb3ac47ddd82b37c4:5fd368489fe44c0f83f1f2e5df10a7ef@sentry.io/251669'
-    config.current_environment = ENV['DEPLOYMENT_ENVIRONMENT'] || Rails.env
-    config.environments = %w[production test]
-    config.release = Version::VERSION
-    config.tags = { app: 'ukhpi' }
-    config.excluded_exceptions += ['ActionController::BadRequest']
+  if ENV['SENTRY_API_KEY']
+    Sentry.init do |config|
+      config.dsn = ENV['SENTRY_API_KEY']
+      config.environment = ENV['DEPLOYMENT_ENVIRONMENT'] || Rails.env
+      config.enabled_environments = %w[production test]
+      config.release = Version::VERSION
+      config.breadcrumbs_logger = %i[active_support_logger http_logger]
+      config.excluded_exceptions += ['ActionController::BadRequest']
+    end
   end
 end


### PR DESCRIPTION
This commit updates to use the recommended `sentry-rails` library for
reporting events to Sentry.

We have also factored out the DSN key so that it can be passed as part
of the environment.
