### PR TITLE
Improved Logging for UKHPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changes to the UKHPI app by version and date
 
+## 1.7.0 - 2023-06-22
+
+- (Jon) Added `NoMethodError` rescue clause set to `debug` level to reduce
+  loggin noise in production as this should be caught in development and test
+  environments.
+- (Jon) Improved logging by using blocks instead of strings as Ruby has to
+  evaluate these strings, which includes instantiating the somewhat heavy String
+  object and interpolating the variables, and which takes time. Therefore, it's
+  recommended to pass blocks to the logger methods, as these are only evaluated
+  if the output level is the same or included in the allowed level (i.e. lazy
+  loading). [Documentation](http://guides.rubyonrails.org/debugging_rails_applications.html#impact-of-logs-on-performance)
+- (Jon) Removed sentry logging from dev instance
+- (Jon) Improved logging status with allowance for the differences between 400
+  and 500 errors handled by the same method.
+- (Jon) Improved Javascript asset delivery by adding `defer` to the script tags.
+  If the defer attribute is set, it specifies that the script is downloaded in
+  parallel to parsing the page, and executed after the page has finished
+  parsing.
+- (Jon) Resolves error level reported to match logs where the logging was
+  reporting 400 instead of 500
+- (Jon) Improved webpacker setup to match newer applications
+- (Jon) Improved logging in perform_query method by combining generated logs
+  into single log for better message
+- (Jon) Resolves rubocop OpenStruct warning
+- (Jon) Now uses the proper logging level as well as provides more details to
+  the logs for the `json_rails_logger` gem
+- (Jon) Refactored cache control - resolves
+  [GH-114](https://github.com/epimorphics/hmlr-linked-data/issues/114)
+- (Jon) Updated header links to apply the appropriate language to the root link
+- (Jon) Updated errors reported as `info` level to `error` level - also resolves
+  the `DEBUG level logs seen in production` issues on this file.
+- (Jon) Updated the `data_service_api` gem to the latest 1.4.0 minor release
+  version.
+  - Also includes minor patch updates for other gems, please see the
+  `Gemfile.lock` for details.
+
 ## 1.6.3 - 2023-06-07
 
 - (Jon) Updated the `json_rails_logger` gem to the latest 1.0.1 patch release.

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,6 @@ gem 'prometheus-client', '~> 4.0'
 gem 'puma'
 gem 'rdf-turtle'
 gem 'rubocop-rails'
-# gem 'sentry-ruby',
 gem 'sentry-rails', '~> 5.7'
 gem 'yajl-ruby', require: 'yajl'
 

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'prometheus-client', '~> 4.0'
 gem 'puma'
 gem 'rdf-turtle'
 gem 'rubocop-rails'
+# gem 'sentry-ruby',
 gem 'sentry-rails', '~> 5.7'
 gem 'yajl-ruby', require: 'yajl'
 
@@ -65,11 +66,11 @@ group :development do
 end
 
 # TODO: For running the app locally for testing you can set this to your local path
-# gem 'data_services_api', '~> 1.3.3', path: '~/Epimorphics/shared/data_services_api/'
+# gem 'data_services_api', '~> 1.4.0', path: '~/Epimorphics/shared/data_services_api/'
 # gem 'json_rails_logger', '~> 1.0.0', path: '~/Epimorphics/shared/json-rails-logger/'
 
 # TODO: In production you want to set this to the gem from the epimorphics package repo
 source 'https://rubygems.pkg.github.com/epimorphics' do
-  gem 'data_services_api', '~> 1.3.3'
+  gem 'data_services_api', '~> 1.4.0'
   gem 'json_rails_logger', '~> 1.0.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rails', '~> 6.0'
 gem 'uglifier', '>= 1.3.0'
 
 gem 'haml-rails'
-gem 'webpacker'
+gem 'webpacker', '~> 5.4', '>= 5.4.4'
 
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     erubi (1.12.0)
     erubis (2.7.0)
     execjs (2.8.1)
-    faraday (1.10.0)
+    faraday (1.10.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -110,8 +110,8 @@ GEM
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.3)
-      multipart-post (>= 1.2, < 3)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
@@ -194,7 +194,7 @@ GEM
       minitest (>= 5.0)
       ruby-progressbar
     mocha (1.13.0)
-    multipart-post (2.1.1)
+    multipart-post (2.3.0)
     nio4r (2.5.8)
     nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
@@ -345,13 +345,13 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yajl-ruby (1.4.2)
+    yajl-ruby (1.4.3)
     zeitwerk (2.6.8)
 
 GEM
   remote: https://rubygems.pkg.github.com/epimorphics/
   specs:
-    data_services_api (1.3.3)
+    data_services_api (1.4.0)
       faraday_middleware (~> 1.2.0)
       json (~> 2.6.1)
       yajl-ruby (~> 1.4.1)
@@ -366,7 +366,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   capybara_minitest_spec
-  data_services_api (~> 1.3.3)!
+  data_services_api (~> 1.4.0)!
   faraday
   faraday_middleware
   font-awesome-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.2)
     rack (2.2.7)
-    rack-proxy (0.7.2)
+    rack-proxy (0.7.6)
       rack
     rack-test (2.1.0)
       rack (>= 1.3)
@@ -335,7 +335,7 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webpacker (5.4.3)
+    webpacker (5.4.4)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
@@ -401,7 +401,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   vcr
   web-console
-  webpacker
+  webpacker (~> 5.4, >= 5.4.4)
   yajl-ruby
 
 BUNDLED WITH

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  before_action :set_locale
+  before_action :set_locale, :change_default_caching_policy
 
   private
 
@@ -19,5 +19,11 @@ class ApplicationController < ActionController::Base
       http_accept_language.compatible_language_from(I18n.available_locales)
 
     I18n.locale = user_locale if Rails.application.config.welsh_language_enabled
+  end
+
+  # Set the default `Cache-Control` header for all requests,
+  # unless overridden in the action
+  def change_default_caching_policy
+    expires_in 2.minutes, public: true, must_revalidate: true if Rails.env.production?
   end
 end

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -130,7 +130,7 @@ class BrowseController < ApplicationController # rubocop:disable Metrics/ClassLe
 
   def render_bad_request(user_selections) # rubocop:disable Metrics/MethodLength
     respond_to do |format|
-      @view_state = OpenStruct.new(user_selections: user_selections)
+      @view_state = { user_selections: user_selections }
 
       format.html do
         render 'exceptions/error_page',

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -134,7 +134,7 @@ class BrowseController < ApplicationController # rubocop:disable Metrics/ClassLe
 
       format.html do
         render 'exceptions/error_page',
-               locals: { status: 400, sentry_code: nil },
+               locals: { status: 500, sentry_code: nil },
                layout: true,
                status: :bad_request
       end

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -121,7 +121,7 @@ class BrowseController < ApplicationController # rubocop:disable Metrics/ClassLe
 
   def view_result(view_state)
     new_params = view_state.user_selections.without('form-action', nil).params
-    Rails.logger.debug { "Redirecting to #{new_params}" }
+    Rails.logger.info { "Redirecting to #{new_params}" }
     redirect_to({
       controller: :browse,
       action: :show

--- a/app/controllers/exceptions_controller.rb
+++ b/app/controllers/exceptions_controller.rb
@@ -20,9 +20,10 @@ class ExceptionsController < ApplicationController
   private
 
   def maybe_report_to_sentry(exception, status_code)
+    return nil if Rails.env.development? # Why are we reporting to Senty in dev?
     return nil unless status_code >= 500
 
     sevent = Sentry.capture_exception(exception)
-    sevent.event_id
+    sevent&.event_id
   end
 end

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -2,8 +2,8 @@
 
 module Version
   MAJOR = 1
-  MINOR = 6
-  PATCH = 3
+  MINOR = 7
+  PATCH = 0
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}"
 end

--- a/app/models/latest_values_command.rb
+++ b/app/models/latest_values_command.rb
@@ -26,7 +26,7 @@ class LatestValuesCommand
     Rails.logger.error("Status: #{e.status}, body: '#{e.service_message}'")
     nil
   rescue RuntimeError => e
-    Rails.logger.error { "Unexpected error #{e.inspect}" }
+    Rails.logger.error { "Runtime error #{e.inspect}" }
     Rails.logger.error(e.class)
     Rails.logger.error(e.backtrace.join("\n"))
     Rails.logger.error { "Caused by: #{e.cause}" } if e.cause

--- a/app/models/latest_values_command.rb
+++ b/app/models/latest_values_command.rb
@@ -17,19 +17,19 @@ class LatestValuesCommand
   def service_api(service) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     service || dataset(:ukhpi)
   rescue Faraday::ConnectionFailed => e
-    Rails.logger.info('Failed to connect to UK HPI ')
-    Rails.logger.info("Status: #{e.status}, body: '#{e.message}'")
-    Rails.logger.info(e)
+    Rails.logger.error('Failed to connect to UK HPI ')
+    Rails.logger.error("Status: #{e.status}, body: '#{e.message}'")
+    Rails.logger.error(e)
     nil
   rescue DataServicesApi::ServiceException => e
-    Rails.logger.info('Failed to get response from UK HPI service')
-    Rails.logger.info("Status: #{e.status}, body: '#{e.service_message}'")
+    Rails.logger.error('Failed to get response from UK HPI service')
+    Rails.logger.error("Status: #{e.status}, body: '#{e.service_message}'")
     nil
   rescue RuntimeError => e
-    Rails.logger.debug { "Unexpected error #{e.inspect}" }
-    Rails.logger.debug(e.class)
-    Rails.logger.debug(e.backtrace.join("\n"))
-    Rails.logger.debug { "Caused by: #{e.cause}" } if e.cause
+    Rails.logger.error { "Unexpected error #{e.inspect}" }
+    Rails.logger.error(e.class)
+    Rails.logger.error(e.backtrace.join("\n"))
+    Rails.logger.error { "Caused by: #{e.cause}" } if e.cause
     nil
   end
 
@@ -40,16 +40,15 @@ class LatestValuesCommand
     query = add_sort_constraint(query)
     query = add_limit_constraint(query)
 
-    Rails.logger.debug { "About to ask DsAPI query: #{query.to_json}" }
     start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond)
     begin
       @results = hpi.query(query)
     rescue RuntimeError => e
-      Rails.logger.warn("DsAPI run_query failed with: #{e.inspect}")
+      Rails.logger.error("API query failed with: #{e.inspect}")
       success = false
     end
     time_taken = (Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond) - start)
-    Rails.logger.debug(format("query took %.0f μs\n", time_taken))
+    Rails.logger.info(format("API query '#{query.to_json}' completed in %.0f μs\n", time_taken))
     success
   end
 

--- a/app/models/latest_values_command.rb
+++ b/app/models/latest_values_command.rb
@@ -17,18 +17,18 @@ class LatestValuesCommand
   def service_api(service) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     service || dataset(:ukhpi)
   rescue Faraday::ConnectionFailed => e
-    Rails.logger.error('Failed to connect to UK HPI ')
-    Rails.logger.error("Status: #{e.status}, body: '#{e.message}'")
-    Rails.logger.error(e)
+    Rails.logger.error { 'Failed to connect to UK HPI ' }
+    Rails.logger.error { "Status: #{e.status}, body: '#{e.message}'" }
+    Rails.logger.error { e }
     nil
   rescue DataServicesApi::ServiceException => e
-    Rails.logger.error('Failed to get response from UK HPI service')
-    Rails.logger.error("Status: #{e.status}, body: '#{e.service_message}'")
+    Rails.logger.error { 'Failed to get response from UK HPI service' }
+    Rails.logger.error { "Status: #{e.status}, body: '#{e.service_message}'" }
     nil
   rescue RuntimeError => e
     Rails.logger.error { "Runtime error #{e.inspect}" }
-    Rails.logger.error(e.class)
-    Rails.logger.error(e.backtrace.join("\n"))
+    Rails.logger.error { e.class }
+    Rails.logger.error { e.backtrace.join("\n") }
     Rails.logger.error { "Caused by: #{e.cause}" } if e.cause
     nil
   end
@@ -43,12 +43,15 @@ class LatestValuesCommand
     start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond)
     begin
       @results = hpi.query(query)
+    rescue NoMethodError => e
+      Rails.logger.debug { "Application failed with: NoMethodError #{e.inspect}" }
+      success = false
     rescue RuntimeError => e
-      Rails.logger.error("API query failed with: #{e.inspect}")
+      Rails.logger.error { "API query failed with: #{e.inspect}" }
       success = false
     end
     time_taken = (Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond) - start)
-    Rails.logger.info(format("API query '#{query.to_json}' completed in %.0f μs\n", time_taken))
+    Rails.logger.info { format("API query '#{query.to_json}' completed in %.0f μs\n", time_taken) }
     success
   end
 

--- a/app/services/query_command.rb
+++ b/app/services/query_command.rb
@@ -17,7 +17,7 @@ class QueryCommand
   def perform_query(service = nil)
     Rails.logger.debug { "About to perform API query: #{query.to_json}" }
     time_taken = execute_query(service, query)
-    Rails.logger.debug(format("query took %.0f μs\n", time_taken))
+    Rails.logger.info(format("API roundtrip took %.0f μs\n", time_taken))
   end
 
   # @return True if this a query execution command

--- a/app/services/query_command.rb
+++ b/app/services/query_command.rb
@@ -46,7 +46,7 @@ class QueryCommand
     dataset(:ukhpi)
   end
 
-  # Run the given query, stash the results, and Return time taken in microseconds.
+  # Run the given query, stash the results, and return time taken in microseconds.
   def execute_query(service, query)
     start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond)
     @results = api_service(service).query(query)

--- a/app/services/query_command.rb
+++ b/app/services/query_command.rb
@@ -15,7 +15,6 @@ class QueryCommand
   # @param service Optional API service end-point to use. Defaults to the UKHPI
   # API service endpoint
   def perform_query(service = nil)
-    Rails.logger.debug { "About to perform API query: #{query.to_json}" }
     time_taken = execute_query(service, query)
     Rails.logger.info(format("API roundtrip took %.0f μs\n", time_taken))
   end
@@ -40,8 +39,7 @@ class QueryCommand
   end
 
   def api_service(service)
-    api_service ||= service || default_service
-    @api_service = api_service
+    @api_service ||= service || default_service
   end
 
   def default_service
@@ -51,8 +49,7 @@ class QueryCommand
   # Run the given query, stash the results, and Return time taken in microseconds.
   def execute_query(service, query)
     start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond)
-    query_results = api_service(service).query(query)
-    @results = query_results
+    @results = api_service(service).query(query)
     (Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond) - start)
   end
 

--- a/app/views/common/_google-analytics.html
+++ b/app/views/common/_google-analytics.html
@@ -1,2 +1,2 @@
 <!-- Global Site Tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-21165003-6"></script>
+<script defer src="https://www.googletagmanager.com/gtag/js?id=UA-21165003-6"></script>

--- a/app/views/common/_header.html.haml
+++ b/app/views/common/_header.html.haml
@@ -10,8 +10,7 @@
       .content
         %a.js-header-toggle.menu{ href: '#proposition-links' } Menu
         %nav#proposition-menu{ 'aria-label' => 'application menu' }
-          %a#proposition-name{ href: "#{Rails.application.config.relative_url_root}" }
-            = t('common.header.app_title')
+          = link_to(t('common.header.app_title'), root_path(lang: I18n.locale), id: "proposition-name")
 
           %ul#proposition-links
             %li

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,7 +8,7 @@
       = I18n.t('common.header.app_title')
     - if Rails.env.production?
       = render partial: 'common/google-analytics'
-      = javascript_include_tag 'cookie'
+      = javascript_include_tag 'cookie', defer: true
       = csrf_meta_tags
     = stylesheet_link_tag 'application', media: 'all'
     = render partial: 'common/favicons'

--- a/app/views/layouts/webpack_application.html.haml
+++ b/app/views/layouts/webpack_application.html.haml
@@ -15,7 +15,7 @@
 
     - if Rails.env.production?
       = render partial: 'common/google-analytics'
-      = javascript_include_tag 'cookie'
+      = javascript_include_tag 'cookie', defer: true
       = csrf_meta_tags
 
     = stylesheet_link_tag 'application', media: 'all'
@@ -34,7 +34,7 @@
       :javascript
         window.isIE8 = true;
 
-    = javascript_pack_tag 'ukhpi_vue'
+    = javascript_pack_tag 'ukhpi_vue', defer: true
 
   %body.government.website.lr
     = render partial: 'common/cookie_banner' if Rails.env.production?

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -7,11 +7,11 @@ default: &default
   public_output_path: packs
   cache_path: tmp/cache/webpacker
   check_yarn_integrity: false
-  webpack_compile_output: false
+  webpack_compile_output: true
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']
-  resolved_paths: []
+  additional_paths: []
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false


### PR DESCRIPTION
This PR is to handle the logging in a manner following the logging guidelines and will resolve ticket [#104](https://github.com/epimorphics/hmlr-linked-data/issues/104)


- Added `NoMethodError` rescue clause set to `debug` level to reduce loggin noise in production as this should be caught in development and test environments.
- Improved logging status with allowance for the differences between 400 and 500 errors handled by the same method.
	- resolves [GH-105](https://github.com/epimorphics/hmlr-linked-data/issues/105)
- Resolves error level reported to match logs where the logging was reporting 400 instead of 500
	- resolves [GH-105](https://github.com/epimorphics/hmlr-linked-data/issues/105)
- Improved logging in `perform_query` method by combining generated logs into single log for better message
- Updated errors reported as `info` level to `error` level 
	- also resolves the `DEBUG level logs seen in production` issue.
- Improved logging in perform_query method by combining generated logs into single log for better message


## Additional Changes

- Now uses the proper logging level as well as provides more details to the logs for the `json_rails_logger` gem
- Updated header links to apply the appropriate language to the root link
- Refactored cache control 
	- resolves [GH-114](https://github.com/epimorphics/hmlr-linked-data/issues/114)
- Resolves rubocop OpenStruct warning
- Improved webpacker setup to match newer applications
- Improved Javascript asset delivery by adding `defer` to the script tags. If the defer attribute is set, it specifies that the script is downloaded in parallel to parsing the page, and executed after the page has finished parsing.
- Improved logging by using blocks instead of strings as Ruby has to evaluate these strings, which includes instantiating the somewhat heavy String object and interpolating the variables, and which takes time. Therefore, it's recommended to pass blocks to the logger methods, as these are only evaluated if the output level is the same or included in the allowed level (i.e. lazy loading). [Documentation](http://guides.rubyonrails.org/debugging_rails_applications.html#impact-of-logs-on-performance)
- Removed sentry logging from dev instance
- Updated the `data_service_api` gem to the latest 1.4.0 minor release version. 
	- Also includes minor patch updates for other gems, please see the `Gemfile.lock` for details.