### PR TITLE
Updated ONS Url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to the UKHPI app by version and date
 
+## 1.7.2 - 2023-11-28
+
+- (Jon) Update to add `www` to the ONS url links on the landing page [GH-133(https://github.com/epimorphics/hmlr-linked-data/issues/133)
+
 ## 1.7.1 - 2023-06-23
 
 - (Jon) Updated the `data_service_api` gem to the latest 1.4.1 patch release

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,7 +3,7 @@
 module Version
   MAJOR = 1
   MINOR = 7
-  PATCH = 1
+  PATCH = 2
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}"
 end

--- a/app/views/landing/_index_en.html.haml
+++ b/app/views/landing/_index_en.html.haml
@@ -46,7 +46,7 @@
     = link_to "Land and Property Services Northern Ireland", "//www.finance-ni.gov.uk/land-property-services-lps"
     and is calculated by the
     = succeed "." do
-      = link_to "Office for National Statistics", "//ons.gov.uk"
+      = link_to "Office for National Statistics", "//www.ons.gov.uk"
     The index applies a statistical method, called a
     = succeed "," do
       = link_to "hedonic regression model", "//www.ons.gov.uk/economy/inflationandpriceindices/methodologies/developmentofasingleofficialhousepriceindex"
@@ -155,5 +155,5 @@
         = image_tag("ros_logo.png", alt: 'Registers of Scotland')
       = link_to("//www.finance-ni.gov.uk/land-property-services-lps", 'aria-label' => 'Go to Land and Property Services home page') do
         = image_tag("lps-identity.png", alt: 'Land and Propert Services')
-      = link_to("//ons.gov.uk", 'aria-label' => 'Go to ONS home page') do
+      = link_to("//www.ons.gov.uk", 'aria-label' => 'Go to ONS home page') do
         = image_tag("ons_logo.png", alt: 'Office for National Statistics')


### PR DESCRIPTION
This PR resolves the linked ticket with the following changes:

- Update to add `www` to the ONS url links on the landing page

- https://github.com/epimorphics/hmlr-linked-data/issues/133