### PR TITLE
Pin rubygems updater version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN apk add --update \
     tzdata \
     yarn \
     && rm -rf /var/cache/apk/* \
-    && gem update --system \
+    && gem install rubygems-update -v 3.4.22 \
+    && update_rubygems \
     && gem install bundler:$BUNDLER_VERSION \
     && bundle config --global frozen 1
 


### PR DESCRIPTION
gem update runs rubygems-update under the hood.
Current versions of rubygems-update (>=3.5.0) require ruby 3.0 or better. 
Last version of rubygems-update compatible with Ruby used here was 3.4.22

@jonrandahl this will likely apply to all the LR apps and indeed any of our ruby apps that have `gem update --system` in the build and are on < 3.0.0 ruby