### PR TITLE
Release Candidate: v1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+## 1.7.3 - 2024-03-15
+
 - (Jon) Updated puma.rb configuration to accept both `RAILS_MIN_THREADS` and
   `RAILS_MAX_THREADS` environment variables to allow a more flexible configuration
   for the application to run in different environments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## unreleased
 
+- (Jon) Updated puma.rb configuration to accept both `RAILS_MIN_THREADS` and
+  `RAILS_MAX_THREADS` environment variables to allow a more flexible configuration
+  for the application to run in different environments.
+  [GH-143](https://github.com/epimorphics/hmlr-linked-data/issues/143)
 - (Jon) Updated the UKHPI contact form links to point to the new contact form
   page; both the English and Welsh versions
   [GH-135](https://github.com/epimorphics/hmlr-linked-data/issues/135)

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,7 +3,7 @@
 module Version
   MAJOR = 1
   MINOR = 7
-  PATCH = 2
+  PATCH = 3
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}"
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -6,8 +6,9 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum, this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch('RAILS_MAX_THREADS', 5).to_i
-threads threads_count, threads_count
+max_threads_count = ENV.fetch('RAILS_MAX_THREADS', 5)
+min_threads_count = ENV.fetch('RAILS_MIN_THREADS', max_threads_count)
+threads min_threads_count, max_threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests, default is 3000.
 #


### PR DESCRIPTION
This pull request contains the following changes in prep for release in version 1.7.3

- Updated puma.rb configuration to accept both `RAILS_MIN_THREADS` and `RAILS_MAX_THREADS` environment variables to allow a more flexible configuration for the application to run in different environments [GH-143](https://github.com/epimorphics/hmlr-linked-data/issues/143)
- Updated the UKHPI contact form links to point to the new contact form page; both the English and Welsh versions [GH-135](https://github.com/epimorphics/hmlr-linked-data/issues/135)
- Update to add `www` to the ONS url links on the landing page [GH-133](https://github.com/epimorphics/hmlr-linked-data/issues/133)