### PR TITLE
Error 500 internal server error when trying to print data table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,33 +7,57 @@
 # Ignore vscode config
 .vscode
 
-# Ignore bundler config.
-!/log/.keep
-.byebug_history
-.yarn-integrity
-.tags
-!/log/.keep
+## Ignore bundler configuration:
 /.bundle
+/vendor/bundle
+/lib/bundler/man/
+
+# Ignore all logfiles and tempfiles.
 /log/*
-/node_modules
+/tmp/*
+!/log/.keep
+!/tmp/.keep
+
+# Ignore Byebug command history file.
+.byebug_history
+
+# Ignore node_modules
+node_modules/
+
+# Ignore precompiled javascript packs
 /public/packs
 /public/packs-test
-/tmp
-bower_components/
-coverage
+/public/assets
+
+# Ignore yarn files
+/yarn-error.log
+yarn-debug.log*
+.yarn-integrity
+
+# Ignore uploaded files in development
+/storage/*
+!/storage/.keep
+/public/uploads
+
+### Rails specific ###
+/public/system
+/coverage/
+/spec/tmp
+
+# Ignore files specific to the development environment
 fc.json
 fc_simple.json
 index-names.txt
 index.json
-node_modules/
-public/assets/
-query-results.json
 tags
 uk.geojson
 uk.json
-yarn-debug.log*
-yarn-error.log
 
+# Used by the location.rake task, don't delete or commit
+query-results.json
+
+# Ignore dot files used by environment or IDE tools
+.tags
 .tool-versions
 .github-token
 .npmrc

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -98,8 +98,6 @@ Rails/ActiveRecordCallbacksOrder:
   Enabled: true
 Rails/FindById:
   Enabled: true
-Rails/I18nLocaleAssignment:
-  Enabled: false
 Rails/Inquiry:
   Enabled: true
 Rails/MailerName:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,25 @@
 
 ## unreleased
 
+## 1.7.4 - 2024-04-19
+
+- (Jon) Updated print presenter to use
+  [`.try(:first)`](https://apidock.com/rails/Object/try) which resolves by
+  returning `nil` without failing if the requested element does not have the
+  method `.first`, i.e. is empty or nil
+  [GH-396](https://github.com/epimorphics/ukhpi/issues/396)
+- (Jon) Updated the print template to include the Google Analytics tracking
+  script for the print page as well as importing shared header content for
+  unification of presentation
+- (Jon) Minor tweaks to the Makefile to remove duplicate variables (`SHORTNAME`)
+  as well as introducing new targets for `check` and `local` for streamlined
+  development tasks
+
 ## 1.7.3 - 2024-03-15
 
 - (Jon) Updated puma.rb configuration to accept both `RAILS_MIN_THREADS` and
-  `RAILS_MAX_THREADS` environment variables to allow a more flexible configuration
-  for the application to run in different environments.
+  `RAILS_MAX_THREADS` environment variables to allow a more flexible
+  configuration for the application to run in different environments.
   [GH-143](https://github.com/epimorphics/hmlr-linked-data/issues/143)
 - (Jon) Updated the UKHPI contact form links to point to the new contact form
   page; both the English and Welsh versions
@@ -32,7 +46,8 @@
   object and interpolating the variables, and which takes time. Therefore, it's
   recommended to pass blocks to the logger methods, as these are only evaluated
   if the output level is the same or included in the allowed level (i.e. lazy
-  loading). [Documentation](http://guides.rubyonrails.org/debugging_rails_applications.html#impact-of-logs-on-performance)
+  loading).
+  [Documentation](http://guides.rubyonrails.org/debugging_rails_applications.html#impact-of-logs-on-performance)
 - (Jon) Removed sentry logging from dev instance
 - (Jon) Improved logging status with allowance for the differences between 400
   and 500 errors handled by the same method.

--- a/Gemfile
+++ b/Gemfile
@@ -39,21 +39,12 @@ gem 'yajl-ruby', require: 'yajl'
 
 group :development, :test do
   gem 'byebug'
-  gem 'capybara_minitest_spec'
   gem 'haml-lint'
   gem 'json_expressions'
-  gem 'm'
-  gem 'minitest-rails', '~> 6.0'
-  gem 'minitest-reporters'
-  # gem 'minitest-spec-rails'
-  gem 'mocha'
   gem 'nokogiri', '1.13.10' # This is the highest version that supports Ruby 2.6
-  gem 'oj'
+  gem 'oj', '3.14.2' # This is the highest version that supports Ruby 2.6
   gem 'rubocop', require: false
-  gem 'selenium-webdriver'
-  gem 'simplecov', require: false
   gem 'tzinfo-data'
-  gem 'vcr'
 end
 
 group :development do
@@ -62,6 +53,18 @@ group :development do
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
+end
+
+group :test do
+  gem 'capybara_minitest_spec'
+  gem 'm'
+  gem 'minitest-rails', '~> 6.0'
+  gem 'minitest-reporters'
+  # gem 'minitest-spec-rails'
+  gem 'mocha'
+  gem 'selenium-webdriver'
+  gem 'simplecov', '0.22.0'
+  gem 'vcr'
 end
 
 # TODO: For running the app locally for testing you can set this to your local path

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,7 +199,7 @@ GEM
     nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    oj (3.13.11)
+    oj (3.14.2)
     parallel (1.22.1)
     parser (3.1.1.0)
       ast (~> 2.4.1)
@@ -300,7 +300,7 @@ GEM
     sentry-ruby (5.7.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
     sexp_processor (4.16.0)
-    simplecov (0.21.2)
+    simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
@@ -385,7 +385,7 @@ DEPENDENCIES
   minitest-reporters
   mocha
   nokogiri (= 1.13.10)
-  oj
+  oj (= 3.14.2)
   prometheus-client (~> 4.0)
   puma
   rails (~> 6.0)
@@ -395,7 +395,7 @@ DEPENDENCIES
   sass-rails
   selenium-webdriver
   sentry-rails (~> 5.7)
-  simplecov
+  simplecov (= 0.22.0)
   spring
   tzinfo-data
   uglifier (>= 1.3.0)
@@ -405,4 +405,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   2.4.20
+   2.4.8

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY:	assets auth check clean image lint local publish realclean run tag test vars
+.PHONY:	assets auth check clean image lint publish realclean run tag test vars
 
 ACCOUNT?=$(shell aws sts get-caller-identity | jq -r .Account)
 ALPINE_VERSION?=3.13
@@ -69,10 +69,6 @@ image: auth
 
 lint: assets
 	@./bin/bundle exec rubocop
-
-local: assets
-	@echo "Starting local server ..."
-	@./bin/rails server -p ${PORT}
 
 publish: image
 	@echo Publishing image: ${REPO}:${TAG} ...

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,9 @@ ${GITHUB_TOKEN}:
 
 assets:
 	@./bin/bundle install
-	@yarn install
+	@echo "Installing yarn packages ..."
+	yarn install
+	@echo "Removing old compiled assets and compiling all the assets named in config.assets.precompile ..."
 	@./bin/rails assets:clean assets:precompile
 
 auth: ${GITHUB_TOKEN} ${BUNDLE_CFG}
@@ -68,11 +70,7 @@ image: auth
 lint: assets
 	@./bin/bundle exec rubocop
 
-local:
-	@echo "Installing all gems ..."
-	@./bin/bundle install
-	@echo "Installing yarn packages ..."
-	yarn install
+local: assets
 	@echo "Starting local server ..."
 	@./bin/rails server -p ${PORT}
 
@@ -102,9 +100,7 @@ tag:
 
 test: assets
 	@echo "Running unit tests ..."
-	@./bin/rails test
-	@echo "Running system tests ..."
-	@./bin/rails test:system
+	@./bin/bundle exec rake test
 
 vars:
 	@echo "Docker: ${REPO}:${TAG}"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY:	assets clean image lint publish realclean run tag test vars
+.PHONY:	assets auth check clean image lint local publish realclean run tag test vars
 
 ACCOUNT?=$(shell aws sts get-caller-identity | jq -r .Account)
 ALPINE_VERSION?=3.13
@@ -7,7 +7,6 @@ BUNDLER_VERSION?=$(shell tail -1 Gemfile.lock | tr -d ' ')
 ECR?=${ACCOUNT}.dkr.ecr.eu-west-1.amazonaws.com
 GPR_OWNER?=epimorphics
 NAME?=$(shell awk -F: '$$1=="name" {print $$2}' deployment.yaml | sed -e 's/[[:blank:]]//g')
-SHORTNAME?=$(shell echo ${NAME} | cut -f2 -d/)
 PAT?=$(shell read -p 'Github access token:' TOKEN; echo $$TOKEN)
 PORT?=3002
 RUBY_VERSION?=$(shell cat .ruby-version)
@@ -18,7 +17,7 @@ API_SERVICE_URL?=http://data-api:8080
 BRANCH:=$(shell git rev-parse --abbrev-ref HEAD)
 COMMIT=$(shell git rev-parse --short HEAD)
 VERSION?=$(shell /usr/bin/env ruby -e 'require "./app/lib/version" ; puts Version::VERSION')
-TAG?=$(shell printf '%s_%s_%08d' ${VERSION} ${COMMIT} ${GITHUB_RUN_NUMBER})
+TAG?=$(shell printf '%s-%s-%08d' ${VERSION} ${COMMIT} ${GITHUB_RUN_NUMBER})
 
 ${TAG}:
 	@echo ${TAG}
@@ -44,6 +43,9 @@ assets:
 
 auth: ${GITHUB_TOKEN} ${BUNDLE_CFG}
 
+check: lint test
+	@echo "All checks passed."
+
 clean:
 	@[ -d public/assets ] && ./bin/rails assets:clobber || :
 	@@ rm -rf bundle coverage log node_modules
@@ -65,6 +67,14 @@ image: auth
 
 lint: assets
 	@./bin/bundle exec rubocop
+
+local:
+	@echo "Installing all gems ..."
+	@./bin/bundle install
+	@echo "Installing yarn packages ..."
+	yarn install
+	@echo "Starting local server ..."
+	@./bin/rails server -p ${PORT}
 
 publish: image
 	@echo Publishing image: ${REPO}:${TAG} ...
@@ -91,7 +101,10 @@ tag:
 	@echo ${TAG}
 
 test: assets
-	@./bin/rails test
+	@echo "Running unit tests ..."
+	@./bin/rails test:unit
+	@echo "Running system tests ..."
+	@./bin/rails test:system
 
 vars:
 	@echo "Docker: ${REPO}:${TAG}"
@@ -102,7 +115,6 @@ vars:
 	@echo "ECR = ${ECR}"
 	@echo "GPR_OWNER = ${GPR_OWNER}"
 	@echo "NAME = ${NAME}"
-	@echo "SHORTNAME = ${SHORTNAME}"
 	@echo "RUBY_VERSION = ${RUBY_VERSION}"
 	@echo "SHORTNAME = ${SHORTNAME}"
 	@echo "STAGE = ${STAGE}"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY:	assets auth check clean image lint publish realclean run tag test vars
+.PHONY:	assets check clean image lint publish realclean run tag test vars
 
 ACCOUNT?=$(shell aws sts get-caller-identity | jq -r .Account)
 ALPINE_VERSION?=3.13
@@ -17,7 +17,7 @@ API_SERVICE_URL?=http://data-api:8080
 BRANCH:=$(shell git rev-parse --abbrev-ref HEAD)
 COMMIT=$(shell git rev-parse --short HEAD)
 VERSION?=$(shell /usr/bin/env ruby -e 'require "./app/lib/version" ; puts Version::VERSION')
-TAG?=$(shell printf '%s-%s-%08d' ${VERSION} ${COMMIT} ${GITHUB_RUN_NUMBER})
+TAG?=$(shell printf '%s_%s_%08d' ${VERSION} ${COMMIT} ${GITHUB_RUN_NUMBER})
 
 ${TAG}:
 	@echo ${TAG}
@@ -38,9 +38,7 @@ ${GITHUB_TOKEN}:
 
 assets:
 	@./bin/bundle install
-	@echo "Installing yarn packages ..."
-	yarn install
-	@echo "Removing old compiled assets and compiling all the assets named in config.assets.precompile ..."
+	@yarn install
 	@./bin/rails assets:clean assets:precompile
 
 auth: ${GITHUB_TOKEN} ${BUNDLE_CFG}

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ tag:
 
 test: assets
 	@echo "Running unit tests ..."
-	@./bin/rails test:unit
+	@./bin/rails test
 	@echo "Running system tests ..."
 	@./bin/rails test:system
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,7 +48,6 @@ class ApplicationController < ActionController::Base
   end
   # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
-
   # Set the user's preferred locale. An explicit locale set via
   # the URL param `lang` is preeminent, otherwise we look to the
   # user's preferred language specified via browser headers

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,7 +3,7 @@
 module Version
   MAJOR = 1
   MINOR = 7
-  PATCH = 3
+  PATCH = 4
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}"
 end

--- a/app/presenters/print_presenter.rb
+++ b/app/presenters/print_presenter.rb
@@ -16,7 +16,7 @@ class PrintPresenter < DownloadPresenter # rubocop:disable Metrics/ClassLength
     DownloadColumn.new(
       label: I18n.t('browse.print.reporting_period').html_safe,
       format: lambda do |row|
-        key = row['ukhpi:refPeriodDuration'].first == 3 ? 'quarterly' : 'monthly'
+        key = row['ukhpi:refPeriodDuration'].try(:first) == 3 ? 'quarterly' : 'monthly'
         val = I18n.t("browse.print.#{key}")
         "<div class='u-text-centre'>#{val}</div>".html_safe
       end
@@ -24,7 +24,7 @@ class PrintPresenter < DownloadPresenter # rubocop:disable Metrics/ClassLength
     DownloadColumn.new(
       label: I18n.t('statistic.volume'),
       format: lambda do |row|
-        val = row['ukhpi:salesVolume'].first
+        val = row['ukhpi:salesVolume'].try(:first)
         "<div class='u-text-right'>#{val}</div>".html_safe
       end
     )
@@ -127,7 +127,7 @@ class PrintPresenter < DownloadPresenter # rubocop:disable Metrics/ClassLength
         stat: stat,
         sep: '<br />',
         format: lambda do |row|
-          val = row["ukhpi:#{ind&.root_name}#{stat.root_name}"].first
+          val = row["ukhpi:#{ind&.root_name}#{stat.root_name}"].try(:first)
           ValueFormatter.format(val,
                                 slug: ind&.root_name,
                                 template: "<div class='u-text-right'>%<formatted>s</div>")

--- a/app/views/layouts/print.html.haml
+++ b/app/views/layouts/print.html.haml
@@ -6,8 +6,10 @@
     %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1, shrink-to-fit=no' }
     %title
       = I18n.t('common.header.app_title')
+    - if Rails.env.production?
+      = render partial: 'common/google-analytics'
+      = csrf_meta_tags
     = stylesheet_link_tag 'application', media: 'all'
-    = csrf_meta_tags
     = render partial: 'common/favicons'
 
     - if @preferences
@@ -25,8 +27,8 @@
       .header-wrapper
         .header-global
           .header-logo
-            %a.content{ href: '/app/ukhpi', title: 'UK HPI' }
-              = image_tag('ukhpi-icon.png', srcset: image_path('ukhpi-icon.svg'))
+            %a.content{ href: "#{Rails.application.config.relative_url_root}", title: t('common.header.home_link') }
+              = image_tag('ukhpi-icon.png', srcset: image_path('ukhpi-icon.svg'), alt: '')
         .header-proposition
           .content
             %nav#proposition-menu

--- a/bin/s-query
+++ b/bin/s-query
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+# rubocop:disable all
 #!/usr/bin/env ruby
 # -*- coding: utf-8 -*-
 
@@ -38,7 +40,7 @@ require 'ostruct'
 SOH_NAME="SOH"
 SOH_VERSION="1.0.0"
 
-$proxy = ENV['http_proxy'] ? URI.parse(ENV['http_proxy']) : OpenStruct.new  
+$proxy = ENV['http_proxy'] ? URI.parse(ENV['http_proxy']) : OpenStruct.new
 
 # What about direct naming?
 
@@ -91,7 +93,7 @@ $hContentLength       = 'Content-Length'
 $hAccept              = 'Accept'
 $hAcceptCharset       = 'Accept-Charset'
 $hAcceptEncoding      = 'Accept-Encoding'
-$hAcceptRanges        = 'Accept-Ranges' 
+$hAcceptRanges        = 'Accept-Ranges'
 
 $headers = { "User-Agent" => "#{SOH_NAME}/Fuseki #{SOH_VERSION}"}
 $print_http = false
@@ -106,7 +108,7 @@ $accept_results="#{$mtSparqlResultsJ} , #{$mtSparqlResultsX};q=0.9 , #{$accept_r
 
 # Accept any in case of trouble.
 $accept_rdf="#{$accept_rdf} , */*;q=0.1"
-$accept_results="#{$accept_results} , */*;q=0.1" 
+$accept_results="#{$accept_results} , */*;q=0.1"
 
 # The media type usually forces the charset.
 $accept_charset=nil
@@ -126,7 +128,7 @@ if ! $cmd.start_with?('s-') && $cmd != 'soh'
   $cmd = 's-'+$cmd
 end
 
-## -------- 
+## --------
 
 def GET(dataset, graph)
   print "GET #{dataset} #{graph}\n" if $verbose
@@ -204,7 +206,7 @@ def send_body(dataset, graph, file, method)
 
   requestURI = target(dataset, graph)
   uri = URI.parse(requestURI)
-  
+
   request = method.new(uri.request_uri)
   request.initialize_http_header(headers)
   print_http_request(uri, request)
@@ -219,7 +221,7 @@ def response_no_body(uri, request)
     http.use_ssl = uri.scheme == 'https'
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE
   end
-  
+
   begin http.start do |http|
       response = http.request(request)
       print_http_response(response)
@@ -235,9 +237,9 @@ def response_no_body(uri, request)
         response.error!
       end
     end
-  rescue Exception => e  
-    # puts e.message  
-    #puts e.backtrace.inspect  
+  rescue Exception => e
+    # puts e.message
+    #puts e.backtrace.inspect
     warn_exit "Failed to connect: #{uri.host}:#{uri.port}: #{e.message}", 3
   end
 end
@@ -249,11 +251,11 @@ def response_print_body(uri, request)
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE
   end
   begin http.start do |http|
-      
+
       # Add a blank line if headers were output.
       print "\n" if $http_print ;
 
-      response = http.request(request) { |res| 
+      response = http.request(request) { |res|
         print_http_response(res)
         #puts res.code
         res.read_body do |segment|
@@ -292,7 +294,7 @@ def print_http_response(response)
 end
 
 def print_headers(marker, headers)
-  headers.each do |k,v| 
+  headers.each do |k,v|
     k = k.split('-').map{|w| w.capitalize}.join('-')+':'
     printf "%s%-20s %s\n",marker,k,v
   end
@@ -341,18 +343,18 @@ def cmd_soh(command=nil)
 
     opts.banner = $banner
     # Define the options, and what they do
-    
+
     options[:verbose] = false
     opts.on( '-v', '--verbose', 'Verbose' ) do
       options[:verbose] = true
     end
-    
+
     options[:version] = false
     opts.on( '--version', 'Print version and exit' ) do
       print "#{SOH_NAME} #{SOH_VERSION}\n"
       exit
     end
-    
+
     # This displays the help screen, all programs are
     # assumed to have this option.
     opts.on( '-h', '--help', 'Display this screen and exit' ) do
@@ -361,7 +363,7 @@ def cmd_soh(command=nil)
     end
   end
 
-  begin optparse.parse!    
+  begin optparse.parse!
   rescue OptionParser::InvalidArgument => e
     warn e
     exit
@@ -394,14 +396,14 @@ def cmd_soh(command=nil)
     warn_exit "Unknown command: #{command}", 2
   end
 
-  if requiredFile 
+  if requiredFile
   then
     if ARGV.size != 3
-      warn_exit "Required: dataset URI, graph URI (or 'default') and file", 1 
+      warn_exit "Required: dataset URI, graph URI (or 'default') and file", 1
     end
   else
     if ARGV.size != 2
-      warn_exit "Required: dataset URI and graph URI (or 'default')", 1 
+      warn_exit "Required: dataset URI and graph URI (or 'default')", 1
     end
   end
 
@@ -451,7 +453,7 @@ def SPARQL_query(service, query, query_file, forcePOST=false, args2={})
    if ! query_file.nil?
     query = open(query_file, 'rb'){|f| f.read}
   end
-  if forcePOST || query.length >= 2*1024 
+  if forcePOST || query.length >= 2*1024
     SPARQL_query_POST(service, query, args2)
   else
     SPARQL_query_GET(service, query, args2)
@@ -517,7 +519,7 @@ def cmd_sparql_query
             'Set the output argument') do |type|
       options[:output]=type
     end
-    opts.on('--accept=TYPE', [:json,:xml,:text,:csv,:tsv], 
+    opts.on('--accept=TYPE', [:json,:xml,:text,:csv,:tsv],
             'Set the accept header type') do |type|
       options[:accept]=type
     end
@@ -531,14 +533,14 @@ def cmd_sparql_query
     opts.on( '--version', 'Print version and exit' ) do
       print "#{SOH_NAME} #{SOH_VERSION}\n"
       exit
-    end 
+    end
     opts.on( '-h', '--help', 'Display this screen and exit' ) do
       puts opts
       exit
     end
   end
 
-  begin optparse.parse!    
+  begin optparse.parse!
   rescue OptionParser::InvalidArgument, OptionParser::InvalidOption => e
     warn e
     exit 1
@@ -644,14 +646,14 @@ def cmd_sparql_update(by_raw_post=true)
     opts.on( '--version', 'Print version and exit' ) do
       print "#{SOH_NAME} #{SOH_VERSION}\n"
       exit
-    end 
+    end
     opts.on( '-h', '--help', 'Display this screen and exit' ) do
       puts opts
       exit
     end
   end
 
-  begin optparse.parse!    
+  begin optparse.parse!
   rescue OptionParser::InvalidArgument => e
     warn e
     exit
@@ -662,7 +664,7 @@ def cmd_sparql_update(by_raw_post=true)
 
   service = options[:service]
   warn_exit 'No service specified. Required --service=URI',1   if service.nil?
-  
+
   update=nil
   update_file=options[:file]
 
@@ -677,7 +679,7 @@ def cmd_sparql_update(by_raw_post=true)
       update = nil
     end
   end
-  
+
   print "SPARQL-Update #{service}\n" if $verbose
   args={}
 
@@ -720,6 +722,8 @@ when "s-update", "sparql-update"
   cmd_sparql_update true
 when "s-update-form", "sparql-update-form"
   cmd_sparql_update false
-else 
+else
   warn_exit "Unknown: "+$cmd, 1
 end
+
+# rubocop:enable all

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,8 +90,8 @@ Rails.application.configure do
   # compiled asset paths
   config.relative_url_root = ENV.fetch('RAILS_RELATIVE_URL_ROOT', '/app/ukhpi')
 
-  # API location is specified in the environment but defaults to the dev service
-  config.api_service_url = ENV.fetch('API_SERVICE_URL')
+  # API location is specified in the environment variable API_SERVICE_URL
+  config.api_service_url = ENV['API_SERVICE_URL']
 
   # feature flag for showing the Welsh language switch affordance
   config.welsh_language_enabled = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,7 +91,7 @@ Rails.application.configure do
   config.relative_url_root = ENV.fetch('RAILS_RELATIVE_URL_ROOT', '/app/ukhpi')
 
   # API location is specified in the environment but defaults to the dev service
-  config.api_service_url = ENV['API_SERVICE_URL']
+  config.api_service_url = ENV.fetch('API_SERVICE_URL')
 
   # feature flag for showing the Welsh language switch affordance
   config.welsh_language_enabled = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -4,7 +4,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers
@@ -91,7 +91,7 @@ Rails.application.configure do
   config.relative_url_root = ENV.fetch('RAILS_RELATIVE_URL_ROOT', '/app/ukhpi')
 
   # API location is specified in the environment variable API_SERVICE_URL
-  config.api_service_url = ENV['API_SERVICE_URL']
+  config.api_service_url = ENV.fetch('API_SERVICE_URL', nil)
 
   # feature flag for showing the Welsh language switch affordance
   config.welsh_language_enabled = true

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -8,7 +8,7 @@ deployments:
   - branch: "preprod"
     deploy: "preprod"
     publish: "preprod"
-  - branch: "dev-infrastructure"
+  - branch: "dev"
     deploy: "dev"
     publish: "dev"
   - branch: "[a-zA-Z0-9]+"


### PR DESCRIPTION
This PR resolves the error reported in ticket #396 by updating the print presenter to use [`.try(:first)`](https://apidock.com/rails/Object/try) which resolves by  returning `nil` without failing if the requested element does not have the  method `.first`, i.e. is empty or nil

## Additional Changes:

- Updated the print template to include the Google Analytics tracking script for the print page as well as importing shared header content for unification of presentation
- Minor tweaks to the Makefile to remove duplicate variables (`SHORTNAME`) as well as introducing new targets for `check` and `local` for streamlined development tasks, alongside removing incorrect and erroneous commands where applicable
- Reorganised .gitignore file to improve readability as well as added comments to group and explain rule application
- Removed duplicated rubocop command
- Reorganised gemfile to create test specific group and lock gem versions to current version of Ruby in use
- Minor Rubocop fixes including preventing rubocop from parsing the `bin/s-query` file which is  used to resolve the fallback location for the Apache Jena Fuseki s-query file added in this [commit](https://github.com/epimorphics/ukhpi/commit/6ba7c50d2d5e7a039f2c462bfd9be659be016b4b)
- Updated deployment.yml to change `dev-infrastructure` branch name to `dev` following branch cleanup