### PR TITLE
Issue/406 a11y 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.7.5 - 2024-08
 
+- (Bogdan) Landing page links should now be more visible [GH-406](https://github.com/epimorphics/ukhpi/issues/406)
 - (Bogdan) Added alt text to application logo [GH-404](https://github.com/epimorphics/ukhpi/issues/404)
 
 ## 1.7.4 - 2024-04-19

--- a/app/assets/stylesheets/landing.scss.erb
+++ b/app/assets/stylesheets/landing.scss.erb
@@ -4,11 +4,7 @@
 
 .c-landing-page {
   a {
-    text-decoration: none;
-
-    &:hover {
-      text-decoration: underline;
-    }
+    text-decoration: underline;
   }
 
   .c-logos {


### PR DESCRIPTION
This PR addresses issue https://github.com/epimorphics/ukhpi/issues/406 by adding underline text decoration for landing page links