### PR TITLE
Issue/416 a11y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.7.5 - 2024-08
 
+- (Bogdan) Fixed type in aria-label text [GH-416](https://github.com/epimorphics/ukhpi/issues/416)
 - (Bogdan) Fixed a duplicate character bug when selecting dates
 - (Bogdan) Added page titles for each individual view [GH-409](https://github.com/epimorphics/ukhpi/issues/409)
 - (Bogdan) Set correct values for `aria-label` link attributes on the about page

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -172,7 +172,7 @@ en:
       data_graph: "See data graph"
       data_table: "See data table"
       compare: "Compare with location ..."
-      select_location: "select a diffent location"
+      select_location: "select a different location"
       cancel: "cancel"
       confirm: "confirm"
       print_table: "print this table"


### PR DESCRIPTION
This PR addresses issue https://github.com/epimorphics/ukhpi/issues/416 by fixing a typo in the aria-label text for the select location input