### PR TITLE
Spike/accessibility issues

### DIFF
--- a/app/javascript/components/data-view-statistics.vue
+++ b/app/javascript/components/data-view-statistics.vue
@@ -17,7 +17,7 @@
           :alt='`marker image for ${statistic.label}`'
         />
         {{ statistic.label }}
-      </label>
+    </label>
   </div>
 </template>
 

--- a/app/javascript/components/data-view-statistics.vue
+++ b/app/javascript/components/data-view-statistics.vue
@@ -1,19 +1,16 @@
 <template lang='html'>
   <div class='o-data-view__js-options-statistics'>
-    <span
-      v-for='(statistic, index) in statistics'
+    <label v-for='(statistic, index) in statistics'
       :key='statistic.slug'
-      class="checkbox-container"
-    >
+      class="checkbox-container">
       <input
         type="checkbox"
-        :id="'checkbox-' + statistic.slug"
         :name='statistic.label'
         :data-slug='statistic.slug'
         @change='onSelectStatistic'
         :checked='isSelectedStatistic(statistic.slug)'
+        @keydown.enter="onSelectStatistic"
       />
-      <label :for="'checkbox-' + statistic.slug">
         <img
           :src='imageSrcPath(index, false)'
           :srcset='imageSrcPath(index, true)'
@@ -21,7 +18,6 @@
         />
         {{ statistic.label }}
       </label>
-    </span>
   </div>
 </template>
 


### PR DESCRIPTION
Changes HTML so that label wraps the checkbox removing the duplicate ID's issue
Adds keydown.enter so that the user can use the return key to check the checkboxes, keeping the original functionality.