### PR TITLE
Improved Prometheus Metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 1.7.5 - 2024-09
 
-- (Dan) Updates the property table ui so the label is clickable
+- (Jon) Swapped the `action_dispatch` subscriber for `action_controller` to
+  allow the `memory_used_mb` and `process_threads` metrics to report correctly
+  (Dan) Updates the property table ui so the label is clickable
 - (Dan) Replaces the buttons for checkboxes on the property tables [GH-431](https://github.com/epimorphics/ukhpi/issues/431)
 - (Jon) Exposed `instrument_internal_error(exception)` metric to the
   `ExceptionsController` to provide a count of internal errors

--- a/app/assets/stylesheets/_ukhpi-statistics.scss
+++ b/app/assets/stylesheets/_ukhpi-statistics.scss
@@ -31,6 +31,10 @@ $graph-colours: (
   flex-wrap: wrap;
   .checkbox-container {
     margin-right: 5px;
+    cursor: pointer;
+    input[type="checkbox"] {
+      cursor: inherit;
+    }
     img {
       max-height: 15px;
       margin-bottom: -1px;

--- a/app/subscribers/action_controller_prometheus_subscriber.rb
+++ b/app/subscribers/action_controller_prometheus_subscriber.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-# Subscribe to :action_dispatch events
-class ActionDispatchPrometheusSubscriber < ActiveSupport::Subscriber
-  attach_to :action_dispatch
+# Subscribe to :action_controller events to monitor memory usage and thread status
+class ActionControllerPrometheusSubscriber < ActiveSupport::Subscriber
+  attach_to :action_controller
 
-  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def process_action(_event)
     mem = GetProcessMem.new
     Prometheus::Client.registry
@@ -56,5 +56,5 @@ class ActionDispatchPrometheusSubscriber < ActiveSupport::Subscriber
                         }
                       )
   end
-  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -49,6 +49,10 @@ environment ENV.fetch('RAILS_ENV', 'development')
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
 
+# Uncomment the following line once ruby is updated to 2.7 or greater to allow
+# the use of the puma-metrics plugin as we're using puma 6.0.0 or greater
+# plugin :metrics
+
 # Use a custom log formatter to emit Puma log messages in a JSON format
 log_formatter do |str|
   {


### PR DESCRIPTION
Swapped the `action_dispatch` subscriber for `action_controller` to allow the `memory_used_mb` and `process_threads` metrics to report correctly.

Also includes comments on puma-metrics and a minor update to the graph checkbox cursor style