### PR TITLE
test: resolving failing test invocation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ group :test do
   # gem 'minitest-spec-rails'
   gem 'mocha'
   gem 'selenium-webdriver'
-  gem 'simplecov', '0.22.0'
+  gem 'simplecov', '0.22.0', require: false
   gem 'vcr'
 end
 

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ tag:
 
 test: assets
 	@echo "Running unit tests ..."
-	@./bin/bundle exec rake test
+	@./bin/rails test
 
 vars:
 	@echo "Docker: ${REPO}:${TAG}"


### PR DESCRIPTION
After adjusting the `make test` target to use `rails` instead of `rake` as it did initially, when running the target the console would error with:

> `require': cannot load such file -- simplecov (LoadError)

Adding `, require: false` to the  'simplecov', '0.22.0' call allows the tests to run and complete:

```sh
Finished in 0.911783s, 174.3836 runs/s, 433.2171 assertions/s.

159 runs, 395 assertions, 0 failures, 0 errors, 0 skips
```