### PR TITLE
Application Configuration Unification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.7.5 - 2024-09
 
+- (Jon) Moved all mirrored configuration settings from individual environments
+  into the application configuration to reduce the need to manage multiple
+  sources of truth
 - (Jon) Actioned all of the outstanding updates contained within the dependabot
   #443 PR as well as all updates implemented via yarn upgrade-interactive thus
   bringing the application to the highest level of update available at this time

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,16 @@ module Ukhpi
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
+    # feature flag for showing the Welsh language switch affordance
+    config.welsh_language_enabled = true
+
+    # Use default paths for documentation.
+    config.accessibility_document_path = '/accessibility'
+    config.privacy_document_path = '/privacy'
+
+    # Set the contact email address to Land Registry supplied address
+    config.contact_email_address = 'data.services@mail.landregistry.gov.uk'
+
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -53,14 +53,4 @@ Rails.application.configure do
 
   # API location can be specified in the environment but defaults to the dev service
   config.api_service_url = ENV.fetch('API_SERVICE_URL', 'http://localhost:8888')
-
-  # feature flag for showing the Welsh language switch affordance
-  config.welsh_language_enabled = true
-
-  # Use default paths for documentation.
-  config.accessibility_document_path = '/doc/accessibility'
-  config.privacy_document_path = '/doc/privacy'
-
-  # Set the contact email address to Land Registry supplied address
-  config.contact_email_address = 'data.services@mail.landregistry.gov.uk'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,14 +92,4 @@ Rails.application.configure do
 
   # API location is specified in the environment variable API_SERVICE_URL
   config.api_service_url = ENV.fetch('API_SERVICE_URL', nil)
-
-  # feature flag for showing the Welsh language switch affordance
-  config.welsh_language_enabled = true
-
-  # Use default paths for documentation.
-  config.accessibility_document_path = '/accessibility'
-  config.privacy_document_path = '/privacy'
-
-  # Set the contact email address to Land Registry supplied address
-  config.contact_email_address = 'data.services@mail.landregistry.gov.uk'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,14 +47,4 @@ Rails.application.configure do
   # API location can be specified in the environment
   # But defaults to the dev service
   config.api_service_url = ENV.fetch('API_SERVICE_URL', 'http://localhost:8080')
-
-  # Use default paths for documentation.
-  config.accessibility_document_path = '/doc/accessibility'
-  config.privacy_document_path = '/doc/privacy'
-
-  # feature flag for showing the Welsh language switch affordance
-  config.welsh_language_enabled = true
-
-  # Set the contact email address to Land Registry supplied address
-  config.contact_email_address = 'data.services@mail.landregistry.gov.uk'
 end


### PR DESCRIPTION
Moved all mirrored configuration settings from individual environments into the application configuration to reduce the need to manage multiple sources