### PR TITLE
Hotfix: Improved Logging Instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changes to the UKHPI app by version and date
 
+## 1.7.6 - 2024-10
+
+- (Jon) Split the error logging into it's own method as well as adjusted the
+  logged message to be either the response message or the response status
+- (Jon) Renamed `render_error` method to `handle_error`
+- (Jon) Set the Internal Error Instrumentation to an `unless` statement to
+  ensure the application does not report internal errors to the Prometheus
+  metrics when the error is a 404 thereby reducing the noise in the Slack alerts
+  channel
+
 ## 1.7.5 - 2024-09
 
 - (Jon) Created a `local` makefile target to allow for local development without

--- a/app/controllers/exceptions_controller.rb
+++ b/app/controllers/exceptions_controller.rb
@@ -4,7 +4,7 @@
 class ExceptionsController < ApplicationController
   layout 'application'
 
-  def render_error
+  def handle_error
     env = request.env
     exception = env['action_dispatch.exception']
     status_code = ActionDispatch::ExceptionWrapper.new(env, exception).status_code

--- a/app/controllers/exceptions_controller.rb
+++ b/app/controllers/exceptions_controller.rb
@@ -10,8 +10,9 @@ class ExceptionsController < ApplicationController
     status_code = ActionDispatch::ExceptionWrapper.new(env, exception).status_code
 
     sentry_code = maybe_report_to_sentry(exception, status_code)
-    # add the exception to the prometheus metrics
-    instrument_internal_error(exception)
+
+    # add the exception to the prometheus metrics but only on errors that are 404
+    instrument_internal_error(exception) unless status_code == 404
 
     render :error_page,
            locals: { status: status_code, sentry_code: sentry_code },
@@ -22,7 +23,7 @@ class ExceptionsController < ApplicationController
   private
 
   def maybe_report_to_sentry(exception, status_code)
-    return nil if Rails.env.development? # Why are we reporting to Senty in dev?
+    return nil if Rails.env.development? # Why are we reporting to Sentry in dev?
     return nil unless status_code >= 500
 
     sevent = Sentry.capture_exception(exception)

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,7 +3,7 @@
 module Version
   MAJOR = 1
   MINOR = 7
-  PATCH = 5
+  PATCH = 6
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}"
 end

--- a/config/initializers/exceptions.rb
+++ b/config/initializers/exceptions.rb
@@ -3,5 +3,5 @@
 # Custom error handling via a Rack middleware action
 Rails.application.config.exceptions_app =
   lambda do |env|
-    ExceptionsController.action(:render_error).call(env)
+    ExceptionsController.action(:handle_error).call(env)
   end


### PR DESCRIPTION
This PR includes the following changes in order to reduce the log noise as a result of improved error handling in the application:

- Set the Internal Error Instrumentation to an `unless` statement to
  ensure the application does not report internal errors to the Prometheus
  metrics when the error is a 404 thereby reducing the noise in the Slack alerts
  channel
- Renamed `render_error` method to `handle_error`
- Split the error logging into it's own method as well as adjusted the
  logged message to be either the response message or the response status
