### PR TITLE
Task: Reduce Metric Alerting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   [GH-149](https://github.com/epimorphics/hmlr-linked-data/issues/149)
 - (Jon) Updated the `maybe_report_to_sentry` method to call the
   `instrument_internal_error` method for reporting internal errors to the
-  Prometheus metrics when neccessary
+  Prometheus metrics when necessary
 - (Jon) Renamed the `handle_error` method to `handle_exceptions` to better
   reflect the method's purpose
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changes to the UKHPI app by version and date
 
+## 2.0.1 - 2024-12
+
+- (Jon) Improves error metrics reporting to ensure that logging always happens
+  with the appropriate severity depending on the exception status while reducing
+  the types of errors that can trigger a an error metric and therefore a
+  notification in slack
+  [GH-149](https://github.com/epimorphics/hmlr-linked-data/issues/149)
+- (Jon) Updated the `maybe_report_to_sentry` method to call the
+  `instrument_internal_error` method for reporting internal errors to the
+  Prometheus metrics when neccessary
+- (Jon) Renamed the `handle_error` method to `handle_exceptions` to better
+  reflect the method's purpose
+
 ## 2.0.0 - 2024-11
 
 - (Bogdan) Updated all gems by regenerating `Gemfile.lock`

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,7 +39,7 @@ class ApplicationController < ActionController::Base
 
   private
 
-  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def detailed_request_log(duration)
     env = request.env
 
@@ -67,14 +67,27 @@ class ApplicationController < ActionController::Base
       Rails.logger.info(JSON.generate(log_fields))
     end
   end
-  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   # Notify subscriber(s) of an internal error event with the payload of the
   # exception once done
-  # @param [Exception] exp the exception that caused the error
+  # @param [exc] exp the exception that caused the error
   # @return [ActiveSupport::Notifications::Event] provides an object-oriented
   # interface to the event
-  def instrument_internal_error(exception)
-    ActiveSupport::Notifications.instrument('internal_error.application', exception: exception)
+  def instrument_internal_error(exc) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    err = {
+      message: exc&.message || exc,
+      status: exc&.status || Rack::Utils::SYMBOL_TO_STATUS_CODE[exc]
+    }
+    err[:type] = exc.class&.name if exc&.class
+    err[:cause] = exc&.cause if exc&.cause
+    err[:backtrace] = exc&.backtrace if exc&.backtrace && Rails.env.development?
+    # Log the exception to the Rails logger with the appropriate severity
+    Rails.logger.send(err[:status] < 500 ? :warn : :error, JSON.generate(err))
+    # Return unless the status code is 500 or greater to ensure subscribers are NOT notified
+    return unless err[:status] >= 500
+
+    # Instrument the internal error event to notify subscribers of the error
+    ActiveSupport::Notifications.instrument('internal_error.application', exception: err)
   end
 end

--- a/app/controllers/exceptions_controller.rb
+++ b/app/controllers/exceptions_controller.rb
@@ -23,6 +23,9 @@ class ExceptionsController < ApplicationController
     return nil if Rails.env.development? # Why are we reporting to Senty in dev?
     return nil unless status_code >= 500
 
+    # add the exception to the prometheus metrics
+    instrument_internal_error(exception)
+
     sevent = Sentry.capture_exception(exception)
     sevent&.event_id
   end

--- a/app/controllers/exceptions_controller.rb
+++ b/app/controllers/exceptions_controller.rb
@@ -4,7 +4,7 @@
 class ExceptionsController < ApplicationController
   layout 'application'
 
-  def render_error
+  def handle_exceptions
     env = request.env
     exception = env['action_dispatch.exception']
     status_code = ActionDispatch::ExceptionWrapper.new(env, exception).status_code

--- a/app/controllers/exceptions_controller.rb
+++ b/app/controllers/exceptions_controller.rb
@@ -10,8 +10,6 @@ class ExceptionsController < ApplicationController
     status_code = ActionDispatch::ExceptionWrapper.new(env, exception).status_code
 
     sentry_code = maybe_report_to_sentry(exception, status_code)
-    # add the exception to the prometheus metrics
-    instrument_internal_error(exception)
 
     render :error_page,
            locals: { status: status_code, sentry_code: sentry_code },

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,7 +3,7 @@
 module Version
   MAJOR = 2
   MINOR = 0
-  PATCH = 0
+  PATCH = 1
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}"
 end

--- a/config/initializers/exceptions.rb
+++ b/config/initializers/exceptions.rb
@@ -3,5 +3,5 @@
 # Custom error handling via a Rack middleware action
 Rails.application.config.exceptions_app =
   lambda do |env|
-    ExceptionsController.action(:render_error).call(env)
+    ExceptionsController.action(:handle_exceptions).call(env)
   end


### PR DESCRIPTION
## 2.0.1 - 2024-12

- Improves error metrics reporting to ensure that logging always happens with the appropriate severity depending on the exception status while reducing the types of errors that can trigger a an error metric and therefore a notification in slack
  [GH-149](https://github.com/epimorphics/hmlr-linked-data/issues/149)
- Updated the `maybe_report_to_sentry` method to call the `instrument_internal_error` method for reporting internal errors to the Prometheus metrics when necessary
- Renamed the `handle_error` method to `handle_exceptions` to better reflect the method's purpose