### PR TITLE
465 NoMethodError: undefined method `[]' for an instance of Faraday::ConnectionFailed (NoMethodError)

### DIFF
--- a/app/assets/stylesheets/_simple-tables.scss
+++ b/app/assets/stylesheets/_simple-tables.scss
@@ -5,28 +5,38 @@
   width: 100%;
   background-color: white;
 
-  td {
-    text-align: right;
-  }
+  tr {
+    &.no-data {
+      td:first-child {
+        text-align: center;
+        padding: 0.5em;
+        color: $grey-2;
+      }
+    }
 
-  td:first-child {
-    text-align: left;
-  }
+    td {
+      text-align: right;
+    }
 
-  th {
-    text-align: center;
-  }
+    td:first-child {
+      text-align: left;
+    }
 
-  th.u-left {
-    text-align: left;
-  }
+    th {
+      text-align: center;
+    }
 
-  th.u-right {
-    text-align: right;
-  }
+    th.u-left {
+      text-align: left;
+    }
 
-  .u-row-odd {
-    background-color: $grey-3;
+    th.u-right {
+      text-align: right;
+    }
+
+    .u-row-odd {
+      background-color: $grey-3;
+    }
   }
 }
 

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -52,8 +52,6 @@ class BrowseController < ApplicationController
     command = query_command.new(user_selections)
     command.perform_query
 
-    raise ArgumentError, 'No data found' if command.results.blank?
-
     DataViewsPresenter.new(user_selections, command.results)
   rescue ArgumentError => e
     { user_selections: user_selections, error: e.message }

--- a/app/controllers/compare_controller.rb
+++ b/app/controllers/compare_controller.rb
@@ -19,8 +19,6 @@ class CompareController < ApplicationController
     user_compare_selections = UserCompareSelections.new(params)
     query_results = perform_query(user_compare_selections) unless user_compare_selections.search?
 
-    raise ArgumentError, 'No data found' unless query_results&.values&.any?(&:present?)
-
     CompareLocationsPresenter.new(user_compare_selections, query_results)
   rescue ArgumentError => e
     { user_selections: user_compare_selections, error: e.message }

--- a/app/models/data_view.rb
+++ b/app/models/data_view.rb
@@ -167,6 +167,8 @@ class DataView # rubocop:disable Metrics/ClassLength
   end
 
   def project_data(query_result, columns)
+    return [] unless query_result.present?
+
     query_result.map do |row_data|
       columns.map do |column|
         datum = row_data[column[:pred]]

--- a/app/presenters/compare_locations_presenter.rb
+++ b/app/presenters/compare_locations_presenter.rb
@@ -149,8 +149,10 @@ class CompareLocationsPresenter # rubocop:disable Metrics/ClassLength
     ensure_even_row_lengths(by_columns)
   end
 
-  def ensure_even_row_lengths(by_columns)
-    max_results = by_columns.map(&:length).max
+  def ensure_even_row_lengths(by_columns) # rubocop:disable Metrics/CyclomaticComplexity
+    return [] unless by_columns&.any?(&:present?)
+
+    max_results = by_columns&.map(&:length).max
 
     by_columns.each do |results|
       results.unshift(nil) while results.length < max_results

--- a/app/views/browse/_data_view.html.haml
+++ b/app/views/browse/_data_view.html.haml
@@ -42,14 +42,19 @@
               %th{ scope: 'col' }
                 = col[:label]
         %tbody
-          - table_data[:data].each do |row|
-            %tr{ class: cycle('u-row-odd', 'u-row-even') }
-              - row.each_with_index do |datum, i|
-                - if i.zero?
-                  %td
-                    = ValueFormatter.month_year(datum)
-                - else
-                  %td
-                    = ValueFormatter.format(datum, slug: data_view.indicator.label)
+          - if table_data[:data].empty?
+            %tr.no-data
+              %td{ colspan: table_data[:columns].size }
+                = t('results.no_data')
+          - else
+            - table_data[:data].each do |row|
+              %tr{ class: cycle('u-row-odd', 'u-row-even') }
+                - row.each_with_index do |datum, i|
+                  - if i.zero?
+                    %td
+                      = ValueFormatter.month_year(datum)
+                  - else
+                    %td
+                      = ValueFormatter.format(datum, slug: data_view.indicator.label)
 
   .o-data-view__vue-root.u-js-only{ data: data_view.as_js_attributes }

--- a/app/views/compare/show.html.haml
+++ b/app/views/compare/show.html.haml
@@ -79,13 +79,18 @@
                   %th{ scope: 'col' }
                     = loc.label
             %tbody
-              - @view_state.query_results_rows.each do |row|
-                %tr{ class: cycle('u-row-odd', 'u-row-even') }
-                  %th{ scope: 'row' }
-                    = row.shift
-                  - row.each do |value|
-                    %td
-                      = ValueFormatter.format(value, slug: @view_state.indicator.label)
+              - if @view_state.query_results_rows.empty?
+                %tr.no-data
+                  %td{ colspan: @view_state.selected_locations.size + 1, class: 'u-text-center' }
+                    = t('results.no_data')
+              - else
+                - @view_state.query_results_rows.each do |row|
+                  %tr{ class: cycle('u-row-odd', 'u-row-even') }
+                    %th{ scope: 'row' }
+                      = row.shift
+                    - row.each do |value|
+                      %td
+                        = ValueFormatter.format(value, slug: @view_state.indicator.label)
 
       #application
         %router-view

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -131,6 +131,9 @@ cy:
   label:
     date: "Dyddiad"
 
+  results:
+     no_data: "Mae’n flin gennym, nid yw data ar gael. Dewiswch leoliad gwahanol."
+
   preposition:
     by: "yn ôl"
     in: "yn"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,6 +131,9 @@ en:
   label:
     date: "Date"
 
+  results:
+    no_data: "Sorry, there is no data available. Please select a different location."
+
   preposition:
     by: "by"
     in: "in"


### PR DESCRIPTION
This PR resolves the breaking error control by dropping handling for empty results in both controllers. Now, if no data is found, it won't raise an exception but will still present the UI as usual. This simplifies the flow and reduces unnecessary errors.

### Additional Changes

- fix: Add no-data handling for empty tables
- style: Refactor simple table styles for better structure
- chore: Add no data message to locales
