### PR TITLE
Task: refactor Sentry logging 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,8 @@ query-results.json
 .tool-versions
 .github-token
 .npmrc
+
+# Ignore local configuration files
+.env
+.env*.local
+!.env.development

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## 2.0.2 - 2025-03
 
+- (Jon) Introduced local config files and updated .gitignore appropriately
+- (Jon) Updated request logging to include path and parameters more clearly
+- (Jon) Added logging for request parameters and path
+- (Jon) Improved error logging in query execution
+- (Jon) Improved `request_time` logging format to show seconds and milliseconds.
+- (Jon) Prevent error rendering in development mode
 - (Jon) Updated Sentry configuration and tagging to include tags for better
   tracking and filtering in Sentry
 - (Jon) Added `development` environment configuration for `dotenv` gem

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -157,6 +157,8 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
 
     if log_fields[:request_time]
       log_fields[:message] += format(', time taken: %.0f ms', log_fields[:request_time])
+      seconds, milliseconds = log_fields[:request_time].divmod(1000)
+      log_fields[:request_time] = format('%.0f.%04d', seconds, milliseconds) # rubocop:disable Style/FormatStringToken
     end
 
     log_response(response.status, log_fields.sort.to_h)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -156,7 +156,7 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
     if log_fields[:request_time]
       log_fields[:message] += format(', time taken: %.0f ms', log_fields[:request_time])
       seconds, milliseconds = log_fields[:request_time].divmod(1000)
-      log_fields[:request_time] = format('%.0f.%04d', seconds, milliseconds) # rubocop:disable Style/FormatStringToken
+      log_fields[:request_time] = format('%.0f.%03d', seconds, milliseconds) # rubocop:disable Style/FormatStringToken
     end
 
     log_response(response.status, log_fields.sort.to_h)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -140,11 +140,9 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
     log_fields[:path] = "#{log_fields[:path]}?#{query}" if query.present?
 
     if log_fields[:message] == 'OK' && log_fields[:status] == 200
-      log_fields[:message] = "Completed request to #{log_fields[:path]}"
+      log_fields[:message] = "Completed request: #{log_fields[:path]}"
       log_fields[:request_status] = 'completed'
     end
-
-    log_fields[:query_string] = query if query.present?
 
     if env['HTTP_USER_AGENT'] && Rails.env.production?
       log_fields[:user_agent] = env['HTTP_USER_AGENT']

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -140,7 +140,7 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
     log_fields[:path] = "#{log_fields[:path]}?#{query}" if query.present?
 
     if log_fields[:message] == 'OK' && log_fields[:status] == 200
-      log_fields[:message] = "Completed request: #{log_fields[:path]}"
+      log_fields[:message] = 'Completed request'
       log_fields[:request_status] = 'completed'
     end
 

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -65,7 +65,7 @@ class BrowseController < ApplicationController
                         else
                           view_state[:user_selections]
                         end
-      render_request_error(user_selections, :internal_server_error)
+      render_request_error(user_selections, :internal_server_error) unless Rails.env.development?
     else
       respond_to do |format|
         format.html

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -7,6 +7,7 @@ class BrowseController < ApplicationController
   layout 'webpack_application'
 
   def show
+    LoggingHelper.log_request({ params: params, path: request.path })
     user_selections = UserSelections.new(params)
 
     if !user_selections.valid?
@@ -14,7 +15,6 @@ class BrowseController < ApplicationController
     elsif explain_non_json?(user_selections)
       redirect_to_html_view(user_selections)
     else
-      LoggingHelper.log_request({ params: params })
       render_view_state(setup_view_state(user_selections))
     end
   end

--- a/app/controllers/compare_controller.rb
+++ b/app/controllers/compare_controller.rb
@@ -39,7 +39,7 @@ class CompareController < ApplicationController
     render 'compare/print', layout: 'print'
   end
 
-  def perform_query(user_compare_selections) # rubocop:disable Metrics/MethodLength
+  def perform_query(user_compare_selections) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     query_results = {}
     base_selection = UserSelections.new(
       __safe_params: {
@@ -49,9 +49,9 @@ class CompareController < ApplicationController
     )
 
     user_compare_selections.selected_locations.each do |location|
-      msg = 'Received Data Services API request from UKHPI service'
-      msg += " for #{location.label}" if location
-      log_fields = { params: base_selection.with('location', location.uri) }
+      log_fields = { params: base_selection.params, path: request.path }
+      msg = 'Received request'
+      msg += " for #{location.label}"
       log_fields[:message] = msg
       LoggingHelper.log_request(log_fields)
       query_results[location.label] = query_with(base_selection, location)

--- a/app/controllers/compare_controller.rb
+++ b/app/controllers/compare_controller.rb
@@ -16,6 +16,7 @@ class CompareController < ApplicationController
   private
 
   def setup_view_state
+    LoggingHelper.log_request({ params: params, path: request.path })
     user_compare_selections = UserCompareSelections.new(params)
     query_results = perform_query(user_compare_selections) unless user_compare_selections.search?
 

--- a/app/controllers/compare_controller.rb
+++ b/app/controllers/compare_controller.rb
@@ -27,7 +27,7 @@ class CompareController < ApplicationController
   def render_interactive(view_state)
     @view_state = view_state
     if view_state.respond_to?(:[]) && view_state[:error]
-      render_request_error(@view_state[:user_selections], :internal_server_error)
+      render_request_error(@view_state[:user_selections], :internal_server_error) unless Rails.env.development? # rubocop:disable Layout.LineLength
     else
       @view_state
     end

--- a/app/controllers/landing_controller.rb
+++ b/app/controllers/landing_controller.rb
@@ -10,6 +10,6 @@ class LandingController < ApplicationController
              else
                Rack::Utils::SYMBOL_TO_STATUS_CODE[:internal_server_error]
              end
-    render_request_error(UserLanguageSelection.new(params), status)
+    render_request_error(UserLanguageSelection.new(params), status) unless Rails.env.development?
   end
 end

--- a/app/controllers/landing_controller.rb
+++ b/app/controllers/landing_controller.rb
@@ -3,6 +3,7 @@
 # :nodoc:
 class LandingController < ApplicationController
   def index
+    LoggingHelper.log_request({ params: params, path: request.path })
     @view_state = LandingState.new(UserLanguageSelection.new(params))
   rescue StandardError => e
     status = if e.respond_to?(:status)

--- a/app/lib/logging_helper.rb
+++ b/app/lib/logging_helper.rb
@@ -29,7 +29,7 @@ class LoggingHelper
     if fields[:request_time]
       fields[:message] += format(', time taken: %.0f ms', fields[:request_time])
       seconds, milliseconds = fields[:request_time].divmod(1000)
-      fields[:request_time] = format('%.0f.%04d', seconds, milliseconds) # rubocop:disable Style/FormatStringToken
+      fields[:request_time] = format('%.0f.%03d', seconds, milliseconds) # rubocop:disable Style/FormatStringToken
     end
 
     # fields[:status] ||= Rack::Utils::SYMBOL_TO_STATUS_CODE[:ok]

--- a/app/lib/logging_helper.rb
+++ b/app/lib/logging_helper.rb
@@ -11,18 +11,18 @@ class LoggingHelper
     fields[:service] = nil
     fields[:params] = nil
     # Set default values for log fields
-    fields[:message] ||= 'Initiating API request'
-    fields[:method] ||= 'GET'
+    fields[:message] ||= 'Received request'
 
     fields[:path] ||= nil
     if service.respond_to?(:data_api) && fields[:path].blank?
+      fields[:message] += ": #{service.data_api}"
       fields[:path] = URI.parse(service.data_api).path
-      # elsif params
-      #   fields[:path] += "?#{JSON.generate(params)}"
+    elsif params.present? && fields[:path].present?
+      query = params.is_a?(Hash) ? params : params.except('permitted', 'controller', 'action').to_unsafe_h
+      fields[:path] += "?#{query.map { |k, v| "#{k}=#{v}" }.join('&')}"
     end
 
-    fields[:message] += ": #{fields[:path]}" if fields[:path]
-
+    fields[:message] += ": #{fields[:path]}" if fields[:path].present?
     fields[:request_status] ||= 'received'
     fields[:request_time] ||= fields[:duration]
 
@@ -32,7 +32,8 @@ class LoggingHelper
       fields[:request_time] = format('%.0f.%04d', seconds, milliseconds) # rubocop:disable Style/FormatStringToken
     end
 
-    fields[:status] ||= Rack::Utils::SYMBOL_TO_STATUS_CODE[:ok]
+    # fields[:status] ||= Rack::Utils::SYMBOL_TO_STATUS_CODE[:ok]
+    fields[:status]
 
     fields.compact! # Finally, remove any nil values before sending to the logger
 

--- a/app/lib/logging_helper.rb
+++ b/app/lib/logging_helper.rb
@@ -15,14 +15,16 @@ class LoggingHelper
 
     fields[:path] ||= nil
     if service.respond_to?(:data_api) && fields[:path].blank?
-      fields[:message] += ": #{service.data_api}"
+      # TODO: Resolve this line once all services are updated to use the new fields
+      # fields[:message] += ": #{service.data_api}"
       fields[:path] = URI.parse(service.data_api).path
     elsif params.present? && fields[:path].present?
-      query = params.is_a?(Hash) ? params : params.except('permitted', 'controller', 'action').to_unsafe_h
+      query = params.is_a?(Hash) ? params : params.except('permitted', 'controller', 'action').to_unsafe_h # rubocop:disable Layout/LineLength
       fields[:path] += "?#{query.map { |k, v| "#{k}=#{v}" }.join('&')}"
     end
 
-    fields[:message] += ": #{fields[:path]}" if fields[:path].present?
+    # TODO: Resolve this line once all services are updated to use the new fields
+    # fields[:message] += ": #{fields[:path]}" if fields[:path].present?
     fields[:request_status] ||= 'received'
     fields[:request_time] ||= fields[:duration]
 
@@ -32,7 +34,6 @@ class LoggingHelper
       fields[:request_time] = format('%.0f.%03d', seconds, milliseconds) # rubocop:disable Style/FormatStringToken
     end
 
-    # fields[:status] ||= Rack::Utils::SYMBOL_TO_STATUS_CODE[:ok]
     fields[:status]
 
     fields.compact! # Finally, remove any nil values before sending to the logger

--- a/app/lib/logging_helper.rb
+++ b/app/lib/logging_helper.rb
@@ -28,6 +28,8 @@ class LoggingHelper
 
     if fields[:request_time]
       fields[:message] += format(', time taken: %.0f ms', fields[:request_time])
+      seconds, milliseconds = fields[:request_time].divmod(1000)
+      fields[:request_time] = format('%.0f.%04d', seconds, milliseconds) # rubocop:disable Style/FormatStringToken
     end
 
     fields[:status] ||= Rack::Utils::SYMBOL_TO_STATUS_CODE[:ok]

--- a/app/models/latest_values_command.rb
+++ b/app/models/latest_values_command.rb
@@ -15,44 +15,41 @@ class LatestValuesCommand
 
   def service_api(service) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     begin
-      log_fields = {}
       log_type = 'error'
       # Set service to ukhpi dataset if not already set
       service ||= dataset(:ukhpi)
     rescue Faraday::ConnectionFailed => e
+      log_fields = { message: 'Failed to connect to UKHPI service' }
       log_fields[:body] = e.message if Rails.logger.debug?
       log_fields[:backtrace] = e&.backtrace&.join("\n") if Rails.logger.debug?
-      log_fields[:message] = 'Failed to connect to UKHPI service'
       log_fields[:request_status] = log_type
       log_fields[:status] = e.status
 
       service = nil
     rescue DataServicesApi::ServiceException => e
+      log_fields = { message: 'Failed to get response from UKHPI service' }
       log_fields[:body] = e.service_message if Rails.logger.debug?
-      log_fields[:message] = 'Failed to get response from UKHPI service'
       log_fields[:request_status] = log_type
       log_fields[:status] = e.status
 
       service = nil
     rescue RuntimeError => e
+      log_fields = { message: "Runtime error #{e.inspect}" }
       log_fields[:body] = "Caused by: #{e.cause} in " if e.cause
       log_fields[:body] += "\r\n(#{e.class})" if Rails.logger.debug?
       log_fields[:backtrace] = e&.backtrace&.join("\n") if Rails.logger.debug?
-      log_fields[:message] = "Runtime error #{e.inspect}"
       log_fields[:request_status] = log_type
       log_fields[:status] = e.status
 
       service = nil
     end
-    # Log the request status and response
-    LoggingHelper.log_request(log_fields, log_type) unless log_fields.empty?
+    # Log the request status and response if there's an error
+    LoggingHelper.log_request(log_fields, log_type) if service.nil?
     # Always return the service object, even if it's nil
     service
   end
 
   def run_query(hpi) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-    log_fields = {}
-    log_type = 'error'
     start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond)
 
     success = true
@@ -61,39 +58,39 @@ class LatestValuesCommand
     query = add_sort_constraint(query)
     query = add_limit_constraint(query)
 
-    # Log the initial request received, passing in the service and query params
-    LoggingHelper.log_request({ service: hpi, params: query })
-
     begin
       @results = hpi.query(query)
-
-      msg = 'processing Data Services API response'
-      log_type = 'info'
     rescue NoMethodError => e
-      msg = "Data Services API request failed with: NoMethodError: #{e}"
+      log_fields = { message: "Data API request failed with: NoMethodError: #{e}"}
       log_fields[:status] = 405 # Method Not Allowed
       success = false
     rescue ArgumentError => e
-      msg = "Data Services API request failed with: ArgumentError: #{e}"
+      log_fields = { message: "Data API request failed with: ArgumentError: #{e}"}
       log_fields[:status] = 422 # Unprocessable Entity
       success = false
     rescue RuntimeError => e
-      msg = "Data Services API request failed with: #{e}"
+      log_fields = { message: "Data API request failed with: #{e}"}
       log_fields[:status] = 400 # Bad Request
       success = false
+    rescue StandardError => e
+      log_fields = { message: "Application failed with: #{e}"}
+      log_fields[:status] = 500 # Internal Server Error
+      success = false
     end
-    # Calculate the time taken to execute the query and pass in the details to be logged
-    time_taken = (Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond) - start) / 1000
-    log_fields[:message] = msg.upcase_first
-    log_fields[:request_status] = success ? 'processing' : 'error'
-    log_fields[:request_time] = time_taken
-    log_fields[:status] ||= Rack::Utils::SYMBOL_TO_STATUS_CODE[:ok] if success
 
-    log_type = 'warn' if (400..499).cover?(log_fields[:status])
+    if success == false # log the error if the request was unsuccessful
+      # Calculate the time taken to execute the query and pass in the details to be logged
+      time_taken = (Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond) - start) / 1000
+      log_fields[:request_status] = 'error'
+      log_fields[:request_time] = time_taken
 
-    # Log the final request status and response
-    LoggingHelper.log_request(log_fields, log_type) unless log_fields.empty?
-    puts "\n" if Rails.env.development? && Rails.logger.debug? # rubocop:disable Rails/Output
+      log_type = 'warn' if (400..499).cover?(log_fields[:status])
+      log_type = 'error' unless success
+      # Log the final request status and response
+      LoggingHelper.log_request(log_fields, log_type)
+      puts "\n" if Rails.env.development? && Rails.logger.debug? # rubocop:disable Rails/Output
+    end
+
     success
   end
 

--- a/app/services/query_command.rb
+++ b/app/services/query_command.rb
@@ -17,14 +17,8 @@ class QueryCommand
   # Perform the UKHPI query encapsulated by this command object
   # @param [DataServicesApi::Service] service the API service to use
   # Defaults to the UKHPI API service endpoint
-  def perform_query(service = nil)
+  def perform_query(service = nil) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     time_taken = execute_query(service, query) / 1000
-    log_fields = { message: 'Processing Data Services API response' }
-    log_fields[:request_status] = 'processing'
-    log_fields[:request_time] = time_taken
-    log_fields[:status] = Rack::Utils::SYMBOL_TO_STATUS_CODE[:ok]
-    LoggingHelper.log_request(log_fields) unless log_fields.empty?
-    puts "\n" if Rails.env.development? && Rails.logger.debug? # rubocop:disable Rails/Output
   end
 
   # @return True if this a query execution command
@@ -63,31 +57,36 @@ class QueryCommand
   def execute_query(service, query) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     begin
       start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond)
-      log_fields = {}
       log_type = 'error'
 
       @results = api_service(service).query(query)
     rescue Faraday::ConnectionFailed => e
+      log_fields = { message: e.message }
       log_fields[:backtrace] = e&.backtrace&.join("\n") if Rails.logger.debug?
-      log_fields[:message] = e.message
-      log_fields[:request_status] = log_type
       log_fields[:status] = 503 # Service Unavailable
     rescue DataServicesApi::ServiceException => e
-      log_fields[:message] = e.service_message
-      log_fields[:request_status] = log_type
+      log_fields = { message: e.service_message }
       log_fields[:status] = 503 # Service Unavailable
     rescue RuntimeError => e
+      log_fields = { message: "Runtime error #{e.inspect}" }
       log_fields[:backtrace] = e&.backtrace&.join("\n") if Rails.logger.debug?
-      log_fields[:message] = "Runtime error #{e.inspect}"
       log_fields[:message] += "Caused by: #{e.cause}" if e.cause
       log_fields[:message] += " in (#{e.class})" if Rails.logger.debug?
-      log_fields[:request_status] = log_type
       log_fields[:status] = 500 # Internal Server Error
     end
-    # Log the request status and response
-    LoggingHelper.log_request(log_fields, log_type) unless log_fields.empty?
+
+    # Calculate the time taken to execute the query and pass in the details to be logged
+    time_taken = (Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond) - start) / 1000
+
+    # Log the final request status and response if there's an error
+    if log_fields.present?
+      log_fields[:request_status] = 'error'
+      log_fields[:request_time] = time_taken
+      LoggingHelper.log_request(log_fields, log_type)
+      puts "\n" if Rails.env.development? && Rails.logger.debug? # rubocop:disable Rails/Output
+    end
     # Always return the time taken to execute the query
-    (Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond) - start)
+    time_taken
   end
 
   # Add a date range constraint to the given query


### PR DESCRIPTION
This PR primarily introduces tags to the Sentry integration allowing deeper filtering and isolation of issues to specific instances, hosts, and environments. This also changes the format of the reported `request_time` property to show as seconds, this means there will be a leading zero and four decimal places, but displayed as a string, not an integer.

- Introduced local config files and updated .gitignore appropriately
- Updated request logging to include path and parameters more clearly
- Added logging for request parameters and path
- Improved error logging in query execution
- Improved `request_time` logging format to show seconds and milliseconds.
- Prevent error rendering in development mode