### PR TITLE
Task: Release Candidate v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 2.1.1 - 2025-04
+
+- (Jon) Updated Data Services Api gem version to include update for ticket
+  [GH-493](https://github.com/epimorphics/ukhpi/issues/493)
+
 ## 2.1.0 - 2025-04
 
 - (Jon) Updated layout template HTML lang attributes for I18n support

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,7 +3,7 @@
 module Version
   MAJOR = 2
   MINOR = 1
-  PATCH = 0
+  PATCH = 1
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}".freeze
 end


### PR DESCRIPTION
This PR updates the changelog and version cadence to reflect the update to the Data Services API gem version. The latest DSAPI gem version includes the solution for ticket #493 to allow the local storage update for the SPARQL link to work as expected.