### PR TITLE
Task: Release candidate v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 2.1.1 - 2025-04
+
+- (Jon) Updated Data Services Api gem version to include update for ticket
+  [GH-493](https://github.com/epimorphics/ukhpi/issues/493)
+
 ## 2.1.0 - 2025-04
 
 - (Jon) Updated layout template HTML lang attributes for I18n support

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -454,7 +454,7 @@ GEM
 GEM
   remote: https://rubygems.pkg.github.com/epimorphics/
   specs:
-    data_services_api (1.5.2)
+    data_services_api (1.5.3)
       faraday_middleware (~> 1.2.0)
       json (~> 2.6.1)
       yajl-ruby (~> 1.4.1)

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,7 +3,7 @@
 module Version
   MAJOR = 2
   MINOR = 1
-  PATCH = 0
+  PATCH = 1
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}".freeze
 end


### PR DESCRIPTION
This PR brings the current updates on the dev branch, for the DSAPI gem version update for ticket #493, into the preprod branch while maintaining the current changes for the LA Boundary updates on the preprod branch.