### PR TITLE
Spike/node docker fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- (Bogdan) Fixed an issue where the `.nvmrc` node version was not respected in Docker
+
 ## 2.1.1 - 2025-04
 
 - (Jon) Updated Data Services Api gem version to include update for ticket

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-ARG ALPINE_VERSION
-ARG RUBY_VERSION
+ARG ALPINE_VERSION=3.20
+ARG RUBY_VERSION=3.3.5
+ARG NODE_VERSION=20
 
 # Defines base image which builder and final stage use
 FROM ruby:${RUBY_VERSION}-alpine${ALPINE_VERSION} as base

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,18 @@ ARG ALPINE_VERSION=3.20
 ARG RUBY_VERSION=3.3.5
 ARG NODE_VERSION=20
 
+# Load node from official build
+FROM node:$NODE_VERSION-alpine AS node
+
 # Defines base image which builder and final stage use
-FROM ruby:${RUBY_VERSION}-alpine${ALPINE_VERSION} as base
+FROM ruby:$RUBY_VERSION-alpine$ALPINE_VERSION AS base
+
+# Copy node binaries from the official image
+COPY --from=node /usr/lib /usr/lib
+COPY --from=node /usr/local/lib /usr/local/lib
+COPY --from=node /usr/local/include /usr/local/include
+COPY --from=node /usr/local/bin /usr/local/bin
+
 ARG BUNDLER_VERSION
 
 RUN apk add --update \

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ image: auth
 	@docker build \
 		--build-arg ALPINE_VERSION=${ALPINE_VERSION} \
 		--build-arg RUBY_VERSION=${RUBY_VERSION} \
+		--build-arg NODE_VERSION=${NODE_VERSION} \
 		--build-arg BUNDLER_VERSION=${BUNDLER_VERSION} \
 		--build-arg VERSION=${VERSION} \
 		--build-arg git_branch=${BRANCH} \
@@ -119,6 +120,7 @@ vars:
 	@echo "GPR_OWNER = ${GPR_OWNER}"
 	@echo "NAME = ${NAME}"
 	@echo "RUBY_VERSION = ${RUBY_VERSION}"
+	@echo "NODE_VERSION = ${NODE_VERSION}"
 	@echo "SHORTNAME = ${SHORTNAME}"
 	@echo "STAGE = ${STAGE}"
 	@echo "COMMIT = ${COMMIT}"

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ NAME?=$(shell awk -F: '$$1=="name" {print $$2}' deployment.yaml | sed -e 's/[[:b
 PAT?=$(shell read -p 'Github access token:' TOKEN; echo $$TOKEN)
 PORT?=3002
 RUBY_VERSION?=$(shell cat .ruby-version)
+NODE_VERSION?=$(shell cat .nvmrc)
 SHORTNAME?=$(shell echo ${NAME} | cut -f2 -d/)
 STAGE?=dev
 API_SERVICE_URL?=http://data-api:8080


### PR DESCRIPTION
This PR fixes an issue where the `.nvmrc` node version was not respected in Docker