### PR TITLE
Task: Update print.html.haml

### DIFF
--- a/app/views/layouts/print.html.haml
+++ b/app/views/layouts/print.html.haml
@@ -34,7 +34,7 @@
         .header-global
           .header-logo
             %a.content{ href: "#{Rails.application.config.relative_url_root}", title: t('common.header.home_link') }
-              = vite_image_tag('images/ukhpi-icon.png', srcset: image_path('ukhpi-icon.svg'), alt: 'UKHPI Logo')
+              = vite_image_tag('images/ukhpi-icon.png', srcset: vite_asset_path('images/ukhpi-icon.svg'), alt: 'UKHPI Logo')
         .header-proposition
           .content
             %nav#proposition-menu


### PR DESCRIPTION
This pull request makes a small change to the way the SVG logo asset is referenced in the print layout. The update ensures that the correct asset path is used for the SVG logo.

* Updated the `srcset` attribute in the logo image tag to use `vite_asset_path` instead of `image_path` for referencing the SVG logo in `app/views/layouts/print.html.haml`.