### PR TITLE
Task: Update Asset helper in print layout

### DIFF
--- a/app/views/layouts/print.html.haml
+++ b/app/views/layouts/print.html.haml
@@ -34,7 +34,7 @@
         .header-global
           .header-logo
             %a.content{ href: "#{Rails.application.config.relative_url_root}", title: t('common.header.home_link') }
-              = vite_image_tag('images/ukhpi-icon.png', srcset: image_path('ukhpi-icon.svg'), alt: 'UKHPI Logo')
+              = vite_image_tag('images/ukhpi-icon.png', srcset: vite_asset_path('images/ukhpi-icon.svg'), alt: 'UKHPI Logo')
         .header-proposition
           .content
             %nav#proposition-menu


### PR DESCRIPTION
This pull request updates the image asset handling in the print layout to ensure consistency with the asset pipeline. The main change is a switch from using `image_path` to `vite_asset_path` for the SVG logo in the `print.html.haml` layout.

Asset pipeline update:

* [`app/views/layouts/print.html.haml`](diffhunk://#diff-e501b0c5d1005f9438df92a1b7214470847d1f4d034dad990b85ad879923c5dfL37-R37): Replaced `image_path` with `vite_asset_path` for the SVG logo in the header to standardize asset referencing and ensure compatibility with Vite.