### PR TITLE
Spike: restore sparql query string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Unused dependency comments and outdated Corepack implementation
 - Redundant `RAILS_ENV=production` from `vite:build` task (already set via ENV)
 
+### Fixed
+
+- Restored SPARQL link to use dynamic `qonsolePath` in downloads
+
 ## [2.2.2] - 2025-11
 
 ### Changed

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -214,7 +214,7 @@ cy:
       date: "Dyddiad"
 
     download:
-      prompt: "Gallwch lawrlwytho’r data hwn er mwyn ei brosesu ymhellach eich hunain. Gallwch <a href='/app/qonsole'>roi cynnig ar yr ymholiad SPARQL</a> hefyd."
+      prompt: "Gallwch lawrlwytho’r data hwn er mwyn ei brosesu ymhellach eich hunain. Gallwch <a href='%{qonsolePath}'>roi cynnig ar yr ymholiad SPARQL</a> hefyd."
       selected: "Lawrlwytho <strong>%{indicatorName}</strong> yn unig yn ôl <strong>%{themeName}</strong> yn %{locationName}:"
       all: "Lawrlwytho <strong>holl ddata Mynegai Prisiau Tai y DU</strong> ar gyfer %{locationName} am y cyfnod hwn:"
       theme: "Lawrlwytho’r <strong>holl</strong> fynegai, pris cyfartalog a newid canrannol yn ôl %{themeName} yn %{locationName}:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -214,7 +214,7 @@ en:
       date: "Date"
 
     download:
-      prompt: "You can download this data, so that you can process it further yourself. You can also <a href='/app/qonsole'>try the SPARQL query</a>."
+      prompt: "You can download this data, so that you can process it further yourself. You can also <a href='%{qonsolePath}'>try the SPARQL query</a>."
       selected: "Download only <strong>%{indicatorName}</strong> by <strong>%{themeName}</strong> in %{locationName}:"
       all: "Download <strong>all UKHPI data</strong> for %{locationName} for this period:"
       theme: "Download <strong>all</strong> of index, average and percentage change by <strong>%{themeName}</strong> in %{locationName}:"


### PR DESCRIPTION
## What's Changed:

- Restores the dynamic SPARQL query string in generated download links
- Ensures correct path resolution for SPARQL queries in the interface