### PR TITLE
Spike: resolve linting again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ BUNDLE_CFG=.bundle/config
 BUNDLE=./bin/bundle
 GITHUB_TOKEN=.github-token
 RAILS=./bin/rails
+SPRING=./bin/spring
 VITE=./bin/vite
 
 ${BUNDLE_CFG}: ${GITHUB_TOKEN}
@@ -220,6 +221,9 @@ tag:
 
 test:
 	@echo "Running unit tests ..."
+# Ensure Spring is stopped to avoid stale state during tests
+	@${SPRING} stop
+# Run Rails tests
 	@${RAILS} test
 
 test-assets:

--- a/app/javascript/components/data-view-graph.vue
+++ b/app/javascript/components/data-view-graph.vue
@@ -15,6 +15,7 @@ export default {
     indicator: {
       required: false,
       type: Object,
+      default: () => ({}),
     },
     theme: {
       required: true,

--- a/app/javascript/lib/app_version.js
+++ b/app/javascript/lib/app_version.js
@@ -19,7 +19,7 @@ import { join } from 'path'
  * import { getAppVersion } from './app/javascript/lib/app_version.js'
  * const version = getAppVersion() // "1.2.3"
  */
-export function getAppVersion() {
+export function getAppVersion () {
   try {
     /** @type {string} Absolute path to version.rb file */
     const versionFilePath = join(process.cwd(), 'app/lib/version.rb')

--- a/app/javascript/router/index.js
+++ b/app/javascript/router/index.js
@@ -8,7 +8,7 @@ Vue.use(Router)
 // # This is a workaround to avoid the issue of Vue Router not being able to handle
 // # relative URLs correctly when using Rails' asset pipeline.
 // Normalise root_path: default to empty string in dev and remove trailing slash, if any
-const relativeUrlRoot = (window.ukhpi?.root_path === '/app/ukhpi' ? window.ukhpi?.root_path : '').replace(/\/$/, '')
+const relativeUrlRoot = (window.ukhpi?.root_path || '').replace(/\/$/, '')
 
 export default new Router({
   routes: [

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -54,6 +54,7 @@ export default defineConfig([
       globals: {
         ...globals.browser,
         ...globals.node,
+        __APP_VERSION__: 'writable',
       },
     },
   },


### PR DESCRIPTION
chore: improve developer workflow and code consistency

- Stops Spring before tests to prevent stale state in CI
- Sets a default for optional indicator prop to ensure no undefined errors
- Simplifies environment variable handling for the root path
- Adds the app version as a writable global for linting purposes
- Standardises function spacing for style consistency