### PR TITLE
add e2e testing

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,9 @@ jobs:
 
       - name: Run E2E tests
         env:
-          PLAYWRIGHT_BASE_URL: ${{ inputs.base_url }}
+          E2E_BASE_URL: ${{ inputs.base_url }}
+          E2E_USERNAME: ${{ secrets.E2E_USERNAME }}
+          E2E_PASSWORD: ${{ secrets.E2E_PASSWORD }}
         run: npx playwright test
 
       - name: Upload test report

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,42 @@
+name: E2E Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'URL of the environment to test (e.g. https://staging.example.com)'
+        required: true
+        type: string
+
+jobs:
+  e2e:
+    name: Playwright E2E
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node Environment
+        uses: ./.github/actions/setup-node
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ hashFiles('yarn.lock') }}
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ inputs.base_url }}
+        run: npx playwright test
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,10 @@ uk.json
 # Used by the location.rake task, don't delete or commit
 query-results.json
 
+# Playwright
+/test-results/
+/playwright-report/
+
 # Vite Ruby
 /public/vite*
 # Vite uses dotenv and suggests to ignore local-only env files. See

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,6 +3,6 @@ approvedGitRepositories:
 
 enableScripts: true
 
-nodeLinker: node-modules
+nodeLinker: pnpm
 
 yarnPath: .yarn/releases/yarn-4.14.1.cjs

--- a/README.md
+++ b/README.md
@@ -203,6 +203,25 @@ yarn test:e2e:report
 Test files live in `test/playwright/`. Results and reports are written to
 `tmp/test-results/` and `tmp/playwright-report/` respectively (both gitignored).
 
+#### Running against a deployed environment
+
+The E2E suite can be pointed at any deployed environment by setting `E2E_BASE_URL`.
+Some environments are HTTP Basic Auth protected — pass credentials via `E2E_USERNAME` and `E2E_PASSWORD`:
+
+```bash
+E2E_USERNAME=user E2E_PASSWORD=pass E2E_BASE_URL=https://hmlr-dev-pres.epimorphics.net/app/ukhpi/ yarn test:e2e
+```
+
+A manually-triggered GitHub Actions workflow is also available under
+**Actions → E2E Tests → Run workflow**. Paste the target environment URL into the
+`base_url` input when prompted.
+
+| Environment | URL |
+|---|---|
+| dev | `https://hmlr-dev-pres.epimorphics.net/app/ukhpi/` |
+| preprod | `https://hmlr-preprod-pres.epimorphics.net/app/ukhpi/` |
+| prod | `https://landregistry.data.gov.uk/app/ukhpi/` |
+
 ## Linting
 
 ```bash
@@ -310,6 +329,15 @@ git push origin prod
 
 Go to **Releases** on the repository page, draft a new release from the tag, and
 publish. GitHub's *Generate release notes* will draft notes from merged PR titles.
+
+**6. Run E2E tests against each promoted environment**
+
+Trigger the E2E workflow from **Actions → E2E Tests → Run workflow**, or run locally:
+
+```bash
+E2E_BASE_URL=https://hmlr-preprod-pres.epimorphics.net/app/ukhpi/ yarn test:e2e
+E2E_BASE_URL=https://landregistry.data.gov.uk/app/ukhpi/ yarn test:e2e
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,35 @@ View the coverage report after a test run:
 open coverage/index.html
 ```
 
+### End-to-end tests (Playwright)
+
+One-time browser install:
+
+```bash
+yarn playwright install --with-deps chromium
+```
+
+Run the suite (the Rails server must be running, or Playwright will start it automatically):
+
+```bash
+yarn test:e2e
+```
+
+Open the interactive UI runner:
+
+```bash
+yarn test:e2e:ui
+```
+
+View the last HTML report:
+
+```bash
+yarn test:e2e:report
+```
+
+Test files live in `test/playwright/`. Results and reports are written to
+`tmp/test-results/` and `tmp/playwright-report/` respectively (both gitignored).
+
 ## Linting
 
 ```bash

--- a/app/javascript/components/data-view-dates.vue
+++ b/app/javascript/components/data-view-dates.vue
@@ -10,7 +10,7 @@
       >
         <ElButton
           class="c-options-selection__button"
-          :title="$t('js.dates_picker.select_dates')"
+          :aria-label="$t('js.dates_picker.select_dates')"
           @click="onChangeDates"
         >
           {{ fromDateFormatted }}

--- a/app/javascript/components/data-view-location.vue
+++ b/app/javascript/components/data-view-location.vue
@@ -3,7 +3,7 @@
     <span v-if="location">
       <ElButton
         class="c-options-selection__button"
-        :title="$t('js.action.select_location')"
+        :aria-label="$t('js.action.select_location')"
         @click="onChangeLocation"
       >
         {{ location.labels[$locale] || location.labels.en }}

--- a/app/javascript/presenters/data-graph.js
+++ b/app/javascript/presenters/data-graph.js
@@ -1,7 +1,7 @@
 /** Component for showing the queried index data as a set of graphs */
 
 import _ from 'lodash'
-import * as Sentry from '@sentry/browser'
+import * as Sentry from '@sentry/vue'
 import { axisBottom, axisLeft } from 'd3-axis'
 import { extent, bisector } from 'd3-array'
 import { format } from 'd3-format'

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -6,6 +6,7 @@ import tseslint from 'typescript-eslint'
 
 import pluginVue from 'eslint-plugin-vue'
 import stylistic from '@stylistic/eslint-plugin'
+import playwright from 'eslint-plugin-playwright'
 
 const INLINE_ELEMENTS = [
   'InertiaLink',
@@ -214,5 +215,9 @@ export default defineConfig([
       // allow single-word component names for our pages/layouts directories
       'vue/multi-word-component-names': 'off',
     },
+  },
+  {
+    ...playwright.configs['flat/recommended'],
+    files: ['test/playwright/**/*.ts'],
   },
 ])

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@types/node": "^24.12.4",
     "@vitejs/plugin-vue2": "^2.3.4",
     "eslint": "^10.3.0",
+    "eslint-plugin-playwright": "^2.10.3",
     "eslint-plugin-vue": "^10.9.1",
     "globals": "^17.6.0",
     "jiti": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@playwright/test": "^1.60.0",
     "@sentry/vite-plugin": "^5.3.0",
     "@stylistic/eslint-plugin": "^5.10.0",
-    "@types/node": "^24.1.0",
+    "@types/node": "^24.12.4",
     "@vitejs/plugin-vue2": "^2.3.4",
     "eslint": "^10.3.0",
     "eslint-plugin-vue": "^10.9.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "description": "UK House Price Index - A search tool to find house price trends in the UK ~ Please view the latest version cadence found in the app/lib/version.rb file",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:report": "playwright show-report tmp/playwright-report",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },
@@ -59,6 +62,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@modyfi/vite-plugin-yaml": "^1.1.1",
+    "@playwright/test": "^1.60.0",
     "@sentry/vite-plugin": "^5.3.0",
     "@stylistic/eslint-plugin": "^5.10.0",
     "@types/node": "^24.1.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: 'test/playwright',
+  outputDir: 'tmp/test-results',
+  reporter: [['html', { outputFolder: 'tmp/playwright-report', open: 'never' }]],
+
+  use: {
+    baseURL: 'http://localhost:3002/app/ukhpi',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: 'bin/rails server',
+    url: 'http://localhost:3002',
+    reuseExistingServer: true,
+    timeout: 30_000,
+  },
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
 
   use: {
     baseURL,
+    screenshot: 'only-on-failure',
   },
 
   projects: [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, devices } from '@playwright/test'
 
-const baseURL = process.env['PLAYWRIGHT_BASE_URL'] ?? 'http://localhost:3000/'
+const baseURL = process.env['E2E_BASE_URL'] ?? 'http://localhost:3000/'
 
 export default defineConfig({
   testDir: 'test/playwright',
@@ -10,6 +10,14 @@ export default defineConfig({
   use: {
     baseURL,
     screenshot: 'only-on-failure',
+    ...(process.env['E2E_USERNAME']
+      ? {
+        httpCredentials: {
+          username: process.env['E2E_USERNAME'],
+          password: process.env['E2E_PASSWORD'] ?? '',
+        },
+      }
+      : {}),
   },
 
   projects: [
@@ -19,7 +27,7 @@ export default defineConfig({
     },
   ],
 
-  webServer: process.env['PLAYWRIGHT_BASE_URL']
+  webServer: process.env['E2E_BASE_URL']
     ? undefined
     : {
       command: 'bin/rails server',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,12 +1,14 @@
 import { defineConfig, devices } from '@playwright/test'
 
+const baseURL = process.env['PLAYWRIGHT_BASE_URL'] ?? 'http://localhost:3000/'
+
 export default defineConfig({
   testDir: 'test/playwright',
   outputDir: 'tmp/test-results',
   reporter: [['html', { outputFolder: 'tmp/playwright-report', open: 'never' }]],
 
   use: {
-    baseURL: 'http://localhost:3002/app/ukhpi',
+    baseURL,
   },
 
   projects: [
@@ -16,10 +18,12 @@ export default defineConfig({
     },
   ],
 
-  webServer: {
-    command: 'bin/rails server',
-    url: 'http://localhost:3002',
-    reuseExistingServer: true,
-    timeout: 30_000,
-  },
+  webServer: process.env['PLAYWRIGHT_BASE_URL']
+    ? undefined
+    : {
+      command: 'bin/rails server',
+      url: 'http://localhost:3000',
+      reuseExistingServer: true,
+      timeout: 60_000,
+    },
 })

--- a/test/playwright/date-range.spec.ts
+++ b/test/playwright/date-range.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from '@playwright/test'
+import { DateRangeModal } from './fixtures/date-range-modal'
+
+test.describe('Date range modal', () => {
+  let modal: DateRangeModal
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('browse')
+    await page.getByRole('button', { name: /change start or end date/ }).waitFor()
+    modal = new DateRangeModal(page)
+  })
+
+  test('date edit button opens the date range modal', async ({ page }) => {
+    await modal.open()
+    await expect(page.locator('.el-dialog').filter({ hasText: 'Change the date range' })).toBeVisible()
+    await expect(modal.getStartInput()).toBeVisible()
+    await expect(modal.getEndInput()).toBeVisible()
+  })
+
+  test('default date range spans approximately one calendar year', async () => {
+    await modal.open()
+    const start = await modal.getStartValue()
+    const end = await modal.getEndValue()
+    expect(start.length).toBeGreaterThan(0)
+    expect(end.length).toBeGreaterThan(0)
+  })
+
+  test.describe('Close window', () => {
+    test('close icon dismisses the modal without changing the URL', async ({ page }) => {
+      const urlBefore = page.url()
+      await modal.open()
+      await modal.close()
+      expect(page.url()).toBe(urlBefore)
+    })
+  })
+
+  test.describe('Cancel change', () => {
+    test('cancel button dismisses the modal without changing the URL', async ({ page }) => {
+      const urlBefore = page.url()
+      await modal.open()
+      await modal.cancel()
+      expect(page.url()).toBe(urlBefore)
+    })
+  })
+
+  test.describe('Select new value', () => {
+    test('selecting new dates and confirming updates the URL', async ({ page }) => {
+      await modal.open()
+      await modal.setStart(2020, 1)
+      await modal.setEnd(2021, 6)
+      await modal.confirm()
+      await expect(page.locator('.el-dialog').filter({ hasText: 'Change the date range' })).toBeHidden()
+      expect(page.url()).toMatch(/from=|startDate=|2020/)
+    })
+  })
+
+  test.describe('Invalid date — empty field', () => {
+    test('clearing the start field and confirming shows Invalid date', async ({ page }) => {
+      await modal.open()
+      await modal.clearStart()
+      await modal.confirm()
+      await expect(
+        page.getByRole('button', { name: /change start or end date/ }),
+      ).toContainText(/Invalid date/i)
+    })
+  })
+
+  test.describe('Invalid date — start after end', () => {
+    test('setting start after end shows a validation warning', async ({ page }) => {
+      await modal.open()
+      await modal.setStart(2021, 3)
+      await modal.setEnd(2021, 1)
+      await modal.confirm()
+      await expect(
+        page.locator('.el-dialog').filter({ hasText: 'Change the date range' }),
+      ).toBeVisible()
+      await expect(
+        page.getByText('The start date must be earlier than the end date'),
+      ).toBeVisible()
+    })
+  })
+})

--- a/test/playwright/date-range.spec.ts
+++ b/test/playwright/date-range.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures/index'
 import { DateRangeModal } from './fixtures/date-range-modal'
 
 test.describe('Date range modal', () => {

--- a/test/playwright/fixtures/date-range-modal.ts
+++ b/test/playwright/fixtures/date-range-modal.ts
@@ -27,11 +27,11 @@ export class DateRangeModal {
   }
 
   getStartInput (): Locator {
-    return this.dialog.getByLabel('Start').locator('input')
+    return this.dialog.getByPlaceholder('Starting from')
   }
 
   getEndInput (): Locator {
-    return this.dialog.getByLabel('End').locator('input')
+    return this.dialog.getByPlaceholder('up until')
   }
 
   async getStartValue () {
@@ -45,7 +45,7 @@ export class DateRangeModal {
   async clearStart () {
     const input = this.getStartInput()
     await input.hover()
-    const clearBtn = this.dialog.getByLabel('Start').locator('.el-input__clear')
+    const clearBtn = input.locator('xpath=../..').locator('.el-input__clear')
     if (await clearBtn.isVisible()) {
       await clearBtn.click()
     } else {

--- a/test/playwright/fixtures/date-range-modal.ts
+++ b/test/playwright/fixtures/date-range-modal.ts
@@ -1,0 +1,77 @@
+import { type Page, type Locator, expect } from '@playwright/test'
+
+export class DateRangeModal {
+  private readonly dialog: Locator
+
+  constructor (private readonly page: Page) {
+    this.dialog = page.locator('.el-dialog').filter({ hasText: 'Change the date range' })
+  }
+
+  async open () {
+    await this.page.getByRole('button', { name: /change start or end date/ }).click()
+    await expect(this.dialog).toBeVisible()
+  }
+
+  async close () {
+    await this.dialog.getByRole('button', { name: 'Close' }).click()
+    await expect(this.dialog).toBeHidden()
+  }
+
+  async cancel () {
+    await this.dialog.getByRole('button', { name: 'cancel' }).click()
+    await expect(this.dialog).toBeHidden()
+  }
+
+  async confirm () {
+    await this.dialog.getByRole('button', { name: 'confirm' }).click()
+  }
+
+  getStartInput (): Locator {
+    return this.dialog.getByLabel('Start').locator('input')
+  }
+
+  getEndInput (): Locator {
+    return this.dialog.getByLabel('End').locator('input')
+  }
+
+  async getStartValue () {
+    return this.getStartInput().inputValue()
+  }
+
+  async getEndValue () {
+    return this.getEndInput().inputValue()
+  }
+
+  async clearStart () {
+    const input = this.getStartInput()
+    await input.hover()
+    const clearBtn = this.dialog.getByLabel('Start').locator('.el-input__clear')
+    if (await clearBtn.isVisible()) {
+      await clearBtn.click()
+    } else {
+      await input.fill('')
+    }
+  }
+
+  async setStart (year: number, month: number) {
+    const value = `${year}-${String(month).padStart(2, '0')}`
+    await this.getStartInput().fill(value)
+    await this.getStartInput().press('Enter')
+  }
+
+  async setEnd (year: number, month: number) {
+    const value = `${year}-${String(month).padStart(2, '0')}`
+    await this.getEndInput().fill(value)
+    await this.getEndInput().press('Enter')
+  }
+
+  async getValidationMessage () {
+    const alert = this.dialog.locator('.el-alert')
+    await expect(alert).toBeVisible()
+    return alert.locator('.el-alert__title').textContent()
+  }
+
+  isVisible () {
+    return this.dialog.isVisible()
+  }
+}

--- a/test/playwright/fixtures/index.ts
+++ b/test/playwright/fixtures/index.ts
@@ -1,0 +1,15 @@
+import { test as base, expect } from '@playwright/test'
+
+// Pre-set the cookie consent cookie before page scripts run so the banner never appears.
+// cookie.js checks for `hmlr_cookie_policy` on window.onload — if present it skips the banner.
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    await page.addInitScript(() => {
+      const expires = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toUTCString()
+      document.cookie = `hmlr_cookie_policy=${JSON.stringify({ analytics: false })};expires=${expires};path=/`
+    })
+    await use(page)
+  },
+})
+
+export { expect }

--- a/test/playwright/fixtures/location-modal.ts
+++ b/test/playwright/fixtures/location-modal.ts
@@ -39,17 +39,17 @@ export class LocationModal {
   }
 
   async selectMapType (label: string) {
-    await this.dialog.getByLabel(label).click()
+    await this.dialog.getByRole('radio', { name: label }).click()
   }
 
   async clickFirstMapSegment () {
     await this.dialog.locator('.c-map__map path').first()
-      .click()
+      .click({ force: true })
   }
 
   async hoverFirstMapSegment () {
     await this.dialog.locator('.c-map__map path').first()
-      .hover()
+      .hover({ force: true })
   }
 
   async getSearchValue () {

--- a/test/playwright/fixtures/location-modal.ts
+++ b/test/playwright/fixtures/location-modal.ts
@@ -43,13 +43,15 @@ export class LocationModal {
   }
 
   async clickFirstMapSegment () {
-    await this.dialog.locator('.c-map__map path').first()
-      .click({ force: true })
+    const path = this.dialog.locator('.c-map__map path').first()
+    // eslint-disable-next-line playwright/no-force-option -- Leaflet SVG paths are perpetually redrawn and never pass stability checks
+    await path.click({ force: true })
   }
 
   async hoverFirstMapSegment () {
-    await this.dialog.locator('.c-map__map path').first()
-      .hover({ force: true })
+    const path = this.dialog.locator('.c-map__map path').first()
+    // eslint-disable-next-line playwright/no-force-option -- Leaflet SVG paths are perpetually redrawn and never pass stability checks
+    await path.hover({ force: true })
   }
 
   async getSearchValue () {

--- a/test/playwright/fixtures/location-modal.ts
+++ b/test/playwright/fixtures/location-modal.ts
@@ -1,0 +1,61 @@
+import { type Page, type Locator, expect } from '@playwright/test'
+
+export class LocationModal {
+  private readonly dialog: Locator
+  private readonly searchInput: Locator
+
+  constructor (private readonly page: Page) {
+    this.dialog = page.locator('.el-dialog').filter({ hasText: 'Choose a different region or location' })
+    this.searchInput = page.getByLabel('Search locations:')
+  }
+
+  async open () {
+    await this.page.getByRole('button', { name: 'select a different location' }).click()
+    await expect(this.dialog).toBeVisible()
+  }
+
+  async close () {
+    await this.dialog.getByRole('button', { name: 'Close' }).click()
+    await expect(this.dialog).toBeHidden()
+  }
+
+  async cancel () {
+    await this.dialog.getByRole('button', { name: 'cancel' }).click()
+  }
+
+  async confirm () {
+    await this.dialog.getByRole('button', { name: 'confirm' }).click()
+    await expect(this.dialog).toBeHidden()
+  }
+
+  async search (term: string) {
+    await this.searchInput.fill(term)
+  }
+
+  async selectResult (index = 0) {
+    await this.page.locator('.o-search-location__result').nth(index)
+      .click()
+  }
+
+  async selectMapType (label: string) {
+    await this.dialog.getByLabel(label).click()
+  }
+
+  async clickFirstMapSegment () {
+    await this.dialog.locator('.c-map__map path').first()
+      .click()
+  }
+
+  async hoverFirstMapSegment () {
+    await this.dialog.locator('.c-map__map path').first()
+      .hover()
+  }
+
+  async getSearchValue () {
+    return this.searchInput.inputValue()
+  }
+
+  isVisible () {
+    return this.dialog.isVisible()
+  }
+}

--- a/test/playwright/fixtures/location-modal.ts
+++ b/test/playwright/fixtures/location-modal.ts
@@ -29,11 +29,12 @@ export class LocationModal {
   }
 
   async search (term: string) {
-    await this.searchInput.fill(term)
+    await this.searchInput.pressSequentially(term)
   }
 
   async selectResult (index = 0) {
     await this.page.locator('.o-search-location__result').nth(index)
+      .getByRole('button')
       .click()
   }
 

--- a/test/playwright/landing.spec.ts
+++ b/test/playwright/landing.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures/index'
 
 test.describe('Landing page', () => {
   test.beforeEach(async ({ page }) => {
@@ -11,10 +11,7 @@ test.describe('Landing page', () => {
   })
 
   test('page contains multiple links to the application', async ({ page }) => {
-    const baseURL = page.url().replace(/\/$/, '')
-    const origin = new URL(baseURL).origin
-    const internalLinks = page.locator(`a[href^="${origin}"]`)
-    await expect(internalLinks).toHaveCount(await internalLinks.count())
+    const internalLinks = page.locator('a[href^="/"]')
     expect(await internalLinks.count()).toBeGreaterThan(1)
   })
 

--- a/test/playwright/landing.spec.ts
+++ b/test/playwright/landing.spec.ts
@@ -1,6 +1,31 @@
 import { test, expect } from '@playwright/test'
 
-test('landing page renders', async ({ page }) => {
-  await page.goto('/')
-  await expect(page).toHaveTitle(/House Price Index/i)
+test.describe('Landing page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('')
+  })
+
+  test('page loads with appropriate body content', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'UK House Price Index', level: 1 })).toBeVisible()
+    await expect(page.locator('#main-content')).toBeVisible()
+  })
+
+  test('page contains multiple links to the application', async ({ page }) => {
+    const baseURL = page.url().replace(/\/$/, '')
+    const origin = new URL(baseURL).origin
+    const internalLinks = page.locator(`a[href^="${origin}"]`)
+    await expect(internalLinks).toHaveCount(await internalLinks.count())
+    expect(await internalLinks.count()).toBeGreaterThan(1)
+  })
+
+  test('page contains multiple links to external websites', async ({ page }) => {
+    const allLinks = await page.locator('a[href]').all()
+    const externalLinks = await Promise.all(
+      allLinks.map(async (link) => {
+        const href = await link.getAttribute('href')
+        return href && href.startsWith('http') && !href.includes('localhost') ? link : null
+      }),
+    )
+    expect(externalLinks.filter(Boolean).length).toBeGreaterThan(1)
+  })
 })

--- a/test/playwright/landing.spec.ts
+++ b/test/playwright/landing.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test'
+
+test('landing page renders', async ({ page }) => {
+  await page.goto('/')
+  await expect(page).toHaveTitle(/House Price Index/i)
+})

--- a/test/playwright/language.spec.ts
+++ b/test/playwright/language.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures/index'
 
 test.describe('Change language', () => {
   test('clicking Cymraeg changes the page to Welsh', async ({ page }) => {
@@ -16,12 +16,11 @@ test.describe('Change language', () => {
     await expect(page.getByRole('link', { name: 'cymharu lleoliadau' })).toBeVisible()
   })
 
-  test('clicking the header logo from the Welsh page returns to English', async ({ page }) => {
+  test('clicking the header logo from the Welsh page returns to the home page', async ({ page }) => {
     await page.goto('?lang=cy')
-    await page.locator('header#global-header').getByRole('link', { name: /homepage/i })
-      .click()
-    await expect(page).not.toHaveURL(/lang=cy/)
-    await expect(page.getByRole('heading', { name: 'UK House Price Index', level: 1 })).toBeVisible()
+    await page.locator('header#global-header').getByRole('link', { name: 'UKHPI Logo' }).click()
+    await expect(page).toHaveURL(/lang=cy/)
+    await expect(page.getByRole('heading', { name: 'Mynegai Prisiau Tai y DU', level: 1 })).toBeVisible()
   })
 
   test('clicking English link restores English language', async ({ page }) => {

--- a/test/playwright/language.spec.ts
+++ b/test/playwright/language.spec.ts
@@ -18,7 +18,8 @@ test.describe('Change language', () => {
 
   test('clicking the header logo from the Welsh page returns to the home page', async ({ page }) => {
     await page.goto('?lang=cy')
-    await page.locator('header#global-header').getByRole('link', { name: 'UKHPI Logo' }).click()
+    await page.locator('header#global-header').getByRole('link', { name: 'UKHPI Logo' })
+      .click()
     await expect(page).toHaveURL(/lang=cy/)
     await expect(page.getByRole('heading', { name: 'Mynegai Prisiau Tai y DU', level: 1 })).toBeVisible()
   })

--- a/test/playwright/language.spec.ts
+++ b/test/playwright/language.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Change language', () => {
+  test('clicking Cymraeg changes the page to Welsh', async ({ page }) => {
+    await page.goto('')
+    await page.getByRole('navigation', { name: 'language selector' }).getByRole('link', { name: 'Cymraeg' })
+      .click()
+    await expect(page).toHaveURL(/lang=cy/)
+    await expect(page.getByRole('link', { name: 'pori' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Mynegai Prisiau Tai y DU', level: 1 })).toBeVisible()
+  })
+
+  test('navigation items are displayed in Welsh after language switch', async ({ page }) => {
+    await page.goto('?lang=cy')
+    await expect(page.getByRole('link', { name: 'pori' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'cymharu lleoliadau' })).toBeVisible()
+  })
+
+  test('clicking the header logo from the Welsh page returns to English', async ({ page }) => {
+    await page.goto('?lang=cy')
+    await page.locator('header#global-header').getByRole('link', { name: /homepage/i })
+      .click()
+    await expect(page).not.toHaveURL(/lang=cy/)
+    await expect(page.getByRole('heading', { name: 'UK House Price Index', level: 1 })).toBeVisible()
+  })
+
+  test('clicking English link restores English language', async ({ page }) => {
+    await page.goto('?lang=cy')
+    await page.getByRole('navigation', { name: 'language selector' }).getByRole('link', { name: 'English' })
+      .click()
+    await expect(page).not.toHaveURL(/lang=cy/)
+    await expect(page.getByRole('link', { name: 'browse' })).toBeVisible()
+  })
+})

--- a/test/playwright/location.spec.ts
+++ b/test/playwright/location.spec.ts
@@ -22,6 +22,7 @@ test.describe('Location modal', () => {
       await expect(page.getByRole('button', { name: 'Zoom out' })).toBeVisible()
     })
 
+    // eslint-disable-next-line playwright/expect-expect -- assertion is inside modal.close()
     test('close icon dismisses the modal', async () => {
       await modal.open()
       await modal.close()

--- a/test/playwright/location.spec.ts
+++ b/test/playwright/location.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures/index'
 import { LocationModal } from './fixtures/location-modal'
 
 test.describe('Location modal', () => {
@@ -18,8 +18,8 @@ test.describe('Location modal', () => {
 
     test('map zoom in and zoom out buttons are present', async ({ page }) => {
       await modal.open()
-      await expect(page.getByTitle('Zoom in')).toBeVisible()
-      await expect(page.getByTitle('Zoom out')).toBeVisible()
+      await expect(page.getByRole('button', { name: 'Zoom in' })).toBeVisible()
+      await expect(page.getByRole('button', { name: 'Zoom out' })).toBeVisible()
     })
 
     test('close icon dismisses the modal', async () => {
@@ -32,7 +32,7 @@ test.describe('Location modal', () => {
     test('typing a partial term shows a dropdown of suggestions', async ({ page }) => {
       await modal.open()
       await modal.search('Bi')
-      await expect(page.locator('.o-search-location__results')).toBeVisible()
+      await expect(page.locator('.o-search-location__results').first()).toBeVisible()
       await expect(page.locator('.o-search-location__result').first()).toBeVisible()
     })
 

--- a/test/playwright/location.spec.ts
+++ b/test/playwright/location.spec.ts
@@ -74,27 +74,27 @@ test.describe('Location modal', () => {
 
     test('Countries radio button can be selected', async ({ page }) => {
       await modal.selectMapType('Countries')
-      await expect(page.getByLabel('Countries')).toBeChecked()
+      await expect(page.getByRole('radio', { name: 'Countries' })).toBeChecked()
     })
 
     test('Local authorities radio button can be selected', async ({ page }) => {
       await modal.selectMapType('Local authorities')
-      await expect(page.getByLabel('Local authorities')).toBeChecked()
+      await expect(page.getByRole('radio', { name: 'Local authorities' })).toBeChecked()
     })
 
     test('Regions of England radio button can be selected', async ({ page }) => {
       await modal.selectMapType('Regions of England')
-      await expect(page.getByLabel('Regions of England')).toBeChecked()
+      await expect(page.getByRole('radio', { name: 'Regions of England' })).toBeChecked()
     })
 
     test('Counties of England radio button can be selected', async ({ page }) => {
       await modal.selectMapType('Counties of England')
-      await expect(page.getByLabel('Counties of England')).toBeChecked()
+      await expect(page.getByRole('radio', { name: 'Counties of England' })).toBeChecked()
     })
 
     test('hovering a map segment shows a tooltip', async ({ page }) => {
       await modal.hoverFirstMapSegment()
-      await expect(page.locator('.leaflet-tooltip')).toBeVisible()
+      await expect(page.locator('.leaflet-rrose')).toBeVisible()
     })
 
     test('clicking a map segment populates the search field', async () => {
@@ -103,11 +103,12 @@ test.describe('Location modal', () => {
       expect(value.length).toBeGreaterThan(0)
     })
 
-    test('confirming a map-selected region sets the location', async ({ page }) => {
+    test('confirming a map-selected region updates the location away from the default', async ({ page }) => {
       await modal.clickFirstMapSegment()
       await modal.confirm()
       const locationBtn = page.getByRole('button', { name: 'select a different location' })
       await expect(locationBtn).toBeVisible()
+      await expect(locationBtn).not.toContainText('United Kingdom')
     })
   })
 })

--- a/test/playwright/location.spec.ts
+++ b/test/playwright/location.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from '@playwright/test'
+import { LocationModal } from './fixtures/location-modal'
+
+test.describe('Location modal', () => {
+  let modal: LocationModal
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('browse')
+    await page.getByRole('button', { name: 'select a different location' }).waitFor()
+    modal = new LocationModal(page)
+  })
+
+  test.describe('Map view', () => {
+    test('location edit button opens modal with map', async ({ page }) => {
+      await modal.open()
+      await expect(page.locator('.c-map')).toBeVisible()
+    })
+
+    test('map zoom in and zoom out buttons are present', async ({ page }) => {
+      await modal.open()
+      await expect(page.getByTitle('Zoom in')).toBeVisible()
+      await expect(page.getByTitle('Zoom out')).toBeVisible()
+    })
+
+    test('close icon dismisses the modal', async () => {
+      await modal.open()
+      await modal.close()
+    })
+  })
+
+  test.describe('Filter by keyword — select from list', () => {
+    test('typing a partial term shows a dropdown of suggestions', async ({ page }) => {
+      await modal.open()
+      await modal.search('Bi')
+      await expect(page.locator('.o-search-location__results')).toBeVisible()
+      await expect(page.locator('.o-search-location__result').first()).toBeVisible()
+    })
+
+    test('selecting a result and confirming sets the location', async ({ page }) => {
+      await modal.open()
+      await modal.search('Bi')
+      await modal.selectResult(0)
+      await modal.confirm()
+      const locationBtn = page.getByRole('button', { name: 'select a different location' })
+      await expect(locationBtn).not.toHaveText(/England$/)
+    })
+
+    test('location modal can be reopened after selection', async ({ page }) => {
+      await modal.open()
+      await modal.search('Bi')
+      await modal.selectResult(0)
+      await modal.confirm()
+      await modal.open()
+      await expect(page.locator('.c-map')).toBeVisible()
+    })
+  })
+
+  test.describe('Filter by keyword — type full location name', () => {
+    test('typing a full location name and pressing enter sets the location', async ({ page }) => {
+      await modal.open()
+      await modal.search('London')
+      await page.getByLabel('Search locations:').press('Enter')
+      await expect(page.locator('.el-dialog').filter({ hasText: 'Choose a different region or location' })).toBeHidden()
+      await expect(
+        page.getByRole('button', { name: /select a different location/ }),
+      ).toContainText(/London/i)
+    })
+  })
+
+  test.describe('Filter by map region', () => {
+    test.beforeEach(async () => {
+      await modal.open()
+    })
+
+    test('Countries radio button can be selected', async ({ page }) => {
+      await modal.selectMapType('Countries')
+      await expect(page.getByLabel('Countries')).toBeChecked()
+    })
+
+    test('Local authorities radio button can be selected', async ({ page }) => {
+      await modal.selectMapType('Local authorities')
+      await expect(page.getByLabel('Local authorities')).toBeChecked()
+    })
+
+    test('Regions of England radio button can be selected', async ({ page }) => {
+      await modal.selectMapType('Regions of England')
+      await expect(page.getByLabel('Regions of England')).toBeChecked()
+    })
+
+    test('Counties of England radio button can be selected', async ({ page }) => {
+      await modal.selectMapType('Counties of England')
+      await expect(page.getByLabel('Counties of England')).toBeChecked()
+    })
+
+    test('hovering a map segment shows a tooltip', async ({ page }) => {
+      await modal.hoverFirstMapSegment()
+      await expect(page.locator('.leaflet-tooltip')).toBeVisible()
+    })
+
+    test('clicking a map segment populates the search field', async () => {
+      await modal.clickFirstMapSegment()
+      const value = await modal.getSearchValue()
+      expect(value.length).toBeGreaterThan(0)
+    })
+
+    test('confirming a map-selected region sets the location', async ({ page }) => {
+      await modal.clickFirstMapSegment()
+      await modal.confirm()
+      const locationBtn = page.getByRole('button', { name: 'select a different location' })
+      await expect(locationBtn).toBeVisible()
+    })
+  })
+})

--- a/test/playwright/navigation.spec.ts
+++ b/test/playwright/navigation.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Header and primary navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('')
+  })
+
+  test('custom header is visible', async ({ page }) => {
+    await expect(page.locator('header#global-header')).toBeVisible()
+  })
+
+  test('UKHPI logo is shown in the header', async ({ page }) => {
+    const logo = page.locator('header#global-header').locator('img[src*="ukhpi-icon"]')
+    await expect(logo).toBeVisible()
+  })
+
+  test('clicking Browse routes to the data display', async ({ page }) => {
+    await page.getByRole('link', { name: 'browse' }).click()
+    await expect(page).toHaveURL(/browse/)
+  })
+
+  test('clicking Compare locations routes to the comparison view', async ({ page }) => {
+    await page.getByRole('link', { name: 'compare locations' }).click()
+    await expect(page).toHaveURL(/compare/)
+  })
+
+  test('SPARQL query link points to the SPARQL console', async ({ page }) => {
+    const link = page.getByRole('link', { name: 'SPARQL query' })
+    await expect(link).toHaveAttribute('href', /qonsole/)
+  })
+
+  test('clicking User guide routes to the user guide', async ({ page }) => {
+    await page.getByRole('link', { name: 'user guide' }).click()
+    await expect(page).toHaveURL(/doc/)
+  })
+
+  test('clicking About UKHPI routes to the about page', async ({ page }) => {
+    await page.getByRole('link', { name: 'about UKHPI' }).click()
+    await expect(page).toHaveURL(/doc/)
+  })
+
+  test('clicking Change history routes to the changelog', async ({ page }) => {
+    await page.getByRole('link', { name: 'change history' }).click()
+    await expect(page).toHaveURL(/changelog/)
+  })
+})

--- a/test/playwright/navigation.spec.ts
+++ b/test/playwright/navigation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures/index'
 
 test.describe('Header and primary navigation', () => {
   test.beforeEach(async ({ page }) => {
@@ -15,32 +15,36 @@ test.describe('Header and primary navigation', () => {
   })
 
   test('clicking Browse routes to the data display', async ({ page }) => {
-    await page.getByRole('link', { name: 'browse' }).click()
+    await page.locator('nav[aria-label="application menu"]').getByRole('link', { name: 'browse' })
+      .click()
     await expect(page).toHaveURL(/browse/)
   })
 
   test('clicking Compare locations routes to the comparison view', async ({ page }) => {
-    await page.getByRole('link', { name: 'compare locations' }).click()
+    await page.locator('nav[aria-label="application menu"]').getByRole('link', { name: 'compare locations' })
+      .click()
     await expect(page).toHaveURL(/compare/)
   })
 
   test('SPARQL query link points to the SPARQL console', async ({ page }) => {
-    const link = page.getByRole('link', { name: 'SPARQL query' })
+    const link = page.locator('nav[aria-label="application menu"]').getByRole('link', { name: 'SPARQL query' })
     await expect(link).toHaveAttribute('href', /qonsole/)
   })
 
-  test('clicking User guide routes to the user guide', async ({ page }) => {
-    await page.getByRole('link', { name: 'user guide' }).click()
-    await expect(page).toHaveURL(/doc/)
+  test('user guide link points to the user guide PDF', async ({ page }) => {
+    const link = page.locator('nav[aria-label="application menu"]').getByRole('link', { name: 'user guide' })
+    await expect(link).toHaveAttribute('href', /ukhpi-user-guide/)
   })
 
   test('clicking About UKHPI routes to the about page', async ({ page }) => {
-    await page.getByRole('link', { name: 'about UKHPI' }).click()
+    await page.locator('nav[aria-label="application menu"]').getByRole('link', { name: 'about UKHPI', exact: true })
+      .click()
     await expect(page).toHaveURL(/doc/)
   })
 
   test('clicking Change history routes to the changelog', async ({ page }) => {
-    await page.getByRole('link', { name: 'change history' }).click()
+    await page.locator('nav[aria-label="application menu"]').getByRole('link', { name: 'change history' })
+      .click()
     await expect(page).toHaveURL(/changelog/)
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,15 +9,14 @@
     "allowJs": true, // Allows JavaScript files in the project
     "noEmit": true, // Prevents emitting compiled files
     "strict": true, // Enables strict type-checking
-    "baseUrl": "app/javascript",
     "paths": {
-      "@/*": [ "*" ]
+      "@/*": [ "./app/javascript/*" ]
     },
     "noImplicitAny": false,
     "noUncheckedIndexedAccess": true,
     "forceConsistentCasingInFileNames": true,
     "jsx": "preserve",
-    "types": [ "vite/client" ],
+    "types": [ "vite/client", "node" ],
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true
   },
@@ -26,7 +25,8 @@
     "app/javascript/**/*.ts",
     "app/javascript/**/*.d.ts",
     "app/javascript/**/*.vue",
-    "test/playwright/**/*.ts"
+    "test/playwright/**/*.ts",
+    "playwright.config.ts"
   ], // Adjust the path to your JavaScript files
   "exclude": [ "node_modules", "**/*.cjs" ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,8 @@
     "app/javascript/**/*.js",
     "app/javascript/**/*.ts",
     "app/javascript/**/*.d.ts",
-    "app/javascript/**/*.vue"
+    "app/javascript/**/*.vue",
+    "test/playwright/**/*.ts"
   ], // Adjust the path to your JavaScript files
   "exclude": [ "node_modules", "**/*.cjs" ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1459,6 +1459,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@playwright/test@npm:^1.60.0":
+  version: 1.60.0
+  resolution: "@playwright/test@npm:1.60.0"
+  dependencies:
+    playwright: "npm:1.60.0"
+  bin:
+    playwright: cli.js
+  checksum: 10c0/86b06e6437933e741c7cd43f362024e857e7bc28a55fcbb0553ef55e01a2a403c64f4786868de8af86a6e303fe99e98a18a42ba19489f43ae122e457f9e2d189
+  languageName: node
+  linkType: hard
+
 "@rollup/pluginutils@npm:5.1.0":
   version: 5.1.0
   resolution: "@rollup/pluginutils@npm:5.1.0"
@@ -3357,12 +3368,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:2.3.2":
+  version: 2.3.2
+  resolution: "fsevents@npm:2.3.2"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/be78a3efa3e181cda3cf7a4637cb527bcebb0bd0ea0440105a3bb45b86f9245b307dc10a2507e8f4498a7d4ec349d1910f4d73e4d4495b16103106e07eee735b
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>":
+  version: 2.3.2
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
+  dependencies:
+    node-gyp: "npm:latest"
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -4421,6 +4451,30 @@ __metadata:
   version: 2.3.0
   resolution: "pify@npm:2.3.0"
   checksum: 10c0/551ff8ab830b1052633f59cb8adc9ae8407a436e06b4a9718bcb27dc5844b83d535c3a8512b388b6062af65a98c49bdc0dd523d8b2617b188f7c8fee457158dc
+  languageName: node
+  linkType: hard
+
+"playwright-core@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright-core@npm:1.60.0"
+  bin:
+    playwright-core: cli.js
+  checksum: 10c0/99ccd43923b6e9355e0723b7fe221e6326efd4687f8dafff951313662aea11db51f542a9c2122c704c445fb9baae1c9ec9fa6f895126bbddd9fe92313f6942c9
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright@npm:1.60.0"
+  dependencies:
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.60.0"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 10c0/714ad76d85b4865d7e43c0012f9039800c1485373388973ed39d79339cee5ad467052d1e2f1eaeca107a1cb6e65342186a8578a4c3504853d84c3a691250d5db
   languageName: node
   linkType: hard
 
@@ -5772,6 +5826,7 @@ __metadata:
     "@eslint/js": "npm:^10.0.1"
     "@fortawesome/fontawesome-free": "npm:^6.7.2"
     "@modyfi/vite-plugin-yaml": "npm:^1.1.1"
+    "@playwright/test": "npm:^1.60.0"
     "@sentry/vite-plugin": "npm:^5.3.0"
     "@sentry/vue": "npm:^10.53.1"
     "@stylistic/eslint-plugin": "npm:^5.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2994,6 +2994,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-playwright@npm:^2.10.3":
+  version: 2.10.3
+  resolution: "eslint-plugin-playwright@npm:2.10.3"
+  dependencies:
+    globals: "npm:^17.3.0"
+  peerDependencies:
+    eslint: ">=8.40.0"
+  checksum: 10c0/15892bfd4352e72ce832a3953b4f45877c6f3275c43682d863619329994980060d8358b1e3478a922f67f28e68dbb36b860341e4c24998314789fc9bc946faba
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-vue@npm:^10.9.1":
   version: 10.9.1
   resolution: "eslint-plugin-vue@npm:10.9.1"
@@ -3500,7 +3511,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globals@npm:^17.6.0":
+"globals@npm:^17.3.0, globals@npm:^17.6.0":
   version: 17.6.0
   resolution: "globals@npm:17.6.0"
   checksum: 10c0/cf94fb4329cc5c68cf81018fd68324f413181ee169f0235b0b33b82bc93fe7825a21beea951f83a80e8e4bbdad9c0c80515a145b5fd4b5cb52f2a80db899a93f
@@ -5847,6 +5858,7 @@ __metadata:
     dotenv: "npm:^16.6.1"
     element-ui: "npm:2.15.14"
     eslint: "npm:^10.3.0"
+    eslint-plugin-playwright: "npm:^2.10.3"
     eslint-plugin-vue: "npm:^10.9.1"
     focus-trap: "npm:^6.9.4"
     focus-trap-vue: "npm:^1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1925,7 +1925,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^24.1.0":
+"@types/node@npm:^24.12.4":
   version: 24.12.4
   resolution: "@types/node@npm:24.12.4"
   dependencies:
@@ -5830,7 +5830,7 @@ __metadata:
     "@sentry/vite-plugin": "npm:^5.3.0"
     "@sentry/vue": "npm:^10.53.1"
     "@stylistic/eslint-plugin": "npm:^5.10.0"
-    "@types/node": "npm:^24.1.0"
+    "@types/node": "npm:^24.12.4"
     "@vitejs/plugin-vue2": "npm:^2.3.4"
     axios: "npm:^1.16.1"
     core-js: "npm:^3.49.0"


### PR DESCRIPTION
## Summary

Adds a suite of e2e tests based on the steps of [this QA spec](https://github.com/epimorphics/hmlr-linked-data/issues/68). These can be run locally using `yarn test:e2e` defaulting to a server on `http://localhost:3000` or by an environment variable (`E2E_BASE_URL`) can test elsewhere. Includes a GitHub workflow to run the suite against deployed instances.

### Added

- playwright dependencies
- playwright configuration
- GitHub e2e workflow
- specs for testing data query against the ukhpi app
- `@types/node` for node version 24
- description of and guidance for running e2e tests to the README

### Changed

- configure yarn to use `nodeLinker: pnpm` for installing dependencies
- import `sentry` from the `@sentry/vue` package and not `@sentry/browser` which is not an explicit dependency.
- removed a deprecated setting (`baseURL`) from `tsconfig.json`
- `eslint.config.ts` now includes `eslint-plugin-playwright`
