### PR TITLE
fix(landing): use semantic lists for contact links and footer logos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed phone number and contact form links on the landing page by using symantic html[#618](https://github.com/epimorphics/ukhpi/issues/618).
+
 ## [2.3.3] - 2026-07-14
 
 ### Added

--- a/app/javascript/stylesheets/_landing.scss
+++ b/app/javascript/stylesheets/_landing.scss
@@ -8,6 +8,14 @@
 
   .c-logos {
     margin-top: 48px;
+    ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    li {
+      display: inline-block;
+    }
     img {
       max-height: 50px;
       max-width: 200px;

--- a/app/views/landing/_index_cy.html.haml
+++ b/app/views/landing/_index_cy.html.haml
@@ -167,24 +167,29 @@
 
   %h2.heading-medium
     Manylion cysylltu
-  %p
-    Ebost
-    = mail_to(Rails.application.config.contact_email_address)
-    %br
-    Ffôn
-    %a{ href: 'tel:+44-300-006-0478'}
-      0300 006 0478
-    %br
-    %a{ href: '//customerhelp.landregistry.gov.uk/welshcontactuswebform/' }
-      Ffurflen gysylltu
+  %ul
+    %li
+      Ebost
+      = mail_to(Rails.application.config.contact_email_address)
+    %li
+      Ffôn
+      %a{ href: 'tel:+44-300-006-0478'}
+        0300 006 0478
+    %li
+      %a{ href: '//customerhelp.landregistry.gov.uk/welshcontactuswebform/' }
+        Ffurflen gysylltu
 
   .c-logos
-    %p.u-text-center
-      = link_to("//www.gov.uk/government/organisations/land-registry.cy", 'aria-label' => '[cy] go to HM Land Registry home page') do
-        = vite_image_tag("images/hm_lr_logo.png", alt: '[cy] HM Land Registry')
-      = link_to("//www.ros.gov.uk/", 'aria-label' => '[cy] Go to Registers of Scotland home page') do
-        = vite_image_tag("images/ros_logo.png", alt: '[cy] Registers of Scotland')
-      = link_to("//www.finance-ni.gov.uk/land-property-services-lps", 'aria-label' => '[cy] Go to Land and Property Services home page') do
-        = vite_image_tag("images/lps-identity.png", alt: '[cy] Land and Propert Services')
-      = link_to("//cy.ons.gov.uk", 'aria-label' => '[cy] Go to ONS home page') do
-        = vite_image_tag("images/ons_logo.png", alt: '[cy] Office for National Statistics')
+    %ul.u-text-center
+      %li
+        = link_to("//www.gov.uk/government/organisations/land-registry.cy", 'aria-label' => '[cy] go to HM Land Registry home page') do
+          = vite_image_tag("images/hm_lr_logo.png", alt: '[cy] HM Land Registry')
+      %li
+        = link_to("//www.ros.gov.uk/", 'aria-label' => '[cy] Go to Registers of Scotland home page') do
+          = vite_image_tag("images/ros_logo.png", alt: '[cy] Registers of Scotland')
+      %li
+        = link_to("//www.finance-ni.gov.uk/land-property-services-lps", 'aria-label' => '[cy] Go to Land and Property Services home page') do
+          = vite_image_tag("images/lps-identity.png", alt: '[cy] Land and Propert Services')
+      %li
+        = link_to("//cy.ons.gov.uk", 'aria-label' => '[cy] Go to ONS home page') do
+          = vite_image_tag("images/ons_logo.png", alt: '[cy] Office for National Statistics')

--- a/app/views/landing/_index_en.html.haml
+++ b/app/views/landing/_index_en.html.haml
@@ -170,25 +170,30 @@
     (OS). HM Land Registry is not responsible for the content or reliability of any linked websites.
 
   %h2.heading-medium Contact details
-  %p
-    Email
-    = mail_to(Rails.application.config.contact_email_address)
-    <br />
-    Telephone
-    %a{ href: 'tel:+44-300-006-0478'}
-      0300 006 0478
-    <br />
-    %a{ href: '//customerhelp.landregistry.gov.uk/guide-page-external/?stepid=2b31bc48-eb96-eb11-b1ac-002248413956' }
-      Contact form
+  %ul
+    %li
+      Email
+      = mail_to(Rails.application.config.contact_email_address)
+    %li
+      Telephone
+      %a{ href: 'tel:+44-300-006-0478'}
+        0300 006 0478
+    %li
+      %a{ href: '//customerhelp.landregistry.gov.uk/guide-page-external/?stepid=2b31bc48-eb96-eb11-b1ac-002248413956' }
+        Contact form
 
 
   .c-logos
-    %p.u-text-center
-      = link_to("//www.gov.uk/government/organisations/land-registry", 'aria-label' => 'go to HM Land Registry home page') do
-        = vite_image_tag("images/hm_lr_logo.png", alt: 'HM Land Registry')
-      = link_to("//www.ros.gov.uk/", 'aria-label' => 'Go to Registers of Scotland home page') do
-        = vite_image_tag("images/ros_logo.png", alt: 'Registers of Scotland')
-      = link_to("//www.finance-ni.gov.uk/land-property-services-lps", 'aria-label' => 'Go to Land and Property Services home page') do
-        = vite_image_tag("images/lps-identity.png", alt: 'Land and Propert Services')
-      = link_to("//www.ons.gov.uk", 'aria-label' => 'Go to ONS home page') do
-        = vite_image_tag("images/ons_logo.png", alt: 'Office for National Statistics')
+    %ul.u-text-center
+      %li
+        = link_to("//www.gov.uk/government/organisations/land-registry", 'aria-label' => 'go to HM Land Registry home page') do
+          = vite_image_tag("images/hm_lr_logo.png", alt: 'HM Land Registry')
+      %li
+        = link_to("//www.ros.gov.uk/", 'aria-label' => 'Go to Registers of Scotland home page') do
+          = vite_image_tag("images/ros_logo.png", alt: 'Registers of Scotland')
+      %li
+        = link_to("//www.finance-ni.gov.uk/land-property-services-lps", 'aria-label' => 'Go to Land and Property Services home page') do
+          = vite_image_tag("images/lps-identity.png", alt: 'Land and Propert Services')
+      %li
+        = link_to("//www.ons.gov.uk", 'aria-label' => 'Go to ONS home page') do
+          = vite_image_tag("images/ons_logo.png", alt: 'Office for National Statistics')


### PR DESCRIPTION
Replaced the contact details `<p>` block with a semantic `<ul>/<li>` list so each contact method (email, phone, contact form) is a distinct list item, on both the English and Welsh landing pages.
Replaced the footer logos `<p>` block with a semantic `<ul class="u-text-center">/<li>` list, updating _landing.scss to style the list (list-style: none, display: inline-block on li) to preserve the original layout.

Fixes screen readers being unable to associate the phone number and contact form link text with their anchors.

Relates to this ticket https://github.com/epimorphics/ukhpi/issues/618