### PR TITLE
fix(footer): render ogl logo as img and fix reflow at 400% zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the Open Government Licence footer logo overlapping the licence text at high browser zoom levels by rendering it as a real `img` element and making its container's absolute positioning responsive, matching the GOV.UK template's own breakpoint [#621](https://github.com/epimorphics/ukhpi/issues/621).
+
 ## [2.3.3] - 2026-07-14
 
 ### Added

--- a/app/javascript/stylesheets/_lr-footer.scss
+++ b/app/javascript/stylesheets/_lr-footer.scss
@@ -9,21 +9,24 @@
     text-decoration: underline;
   }
 
-  .footer-meta .footer-meta-inner .logo {
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 41px;
-    height: 100%;
+  @media (min-width: 641px) {
+    .footer-meta .footer-meta-inner .logo {
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 41px;
+      height: 100%;
+    }
   }
 
   .footer-meta .footer-meta-inner .open-government-licence .logo a {
-    background-image: url('../images/ogl-symbol-41px-black.png');
+    display: block;
+  }
+
+  .footer-meta .footer-meta-inner .open-government-licence .logo img {
     display: block;
     width: 41px;
-    height: 17px;
-    overflow: hidden;
-    text-indent: -999em;
+    height: auto;
   }
 
   .footer-meta .footer-meta-inner .open-government-licence p {

--- a/app/views/common/_footer.html.haml
+++ b/app/views/common/_footer.html.haml
@@ -22,7 +22,7 @@
         .ogl.open-government-licence
           %p.logo.u-print-hidden
             %a{href: t('common.footer.ogl_url'), rel:"license"}
-              = t('common.footer.ogl')
+              = vite_image_tag("images/ogl-symbol-41px-black.png", alt: t('common.footer.ogl'))
           %p
             = t('common.footer.ogl_statement').html_safe
         .clearfix


### PR DESCRIPTION
Fixes the OGL logo overlapping the licence text at high browser zoom (400%+). 
Relates to this ticket https://github.com/epimorphics/ukhpi/issues/621
BEFORE
<img width="2199" height="595" alt="Screenshot from 2026-07-22 15-52-58" src="https://github.com/user-attachments/assets/2413ba34-f3c7-4bd8-aec4-5af2eb851ee3" />
AFTER
<img width="2199" height="934" alt="Screenshot from 2026-07-22 15-55-40" src="https://github.com/user-attachments/assets/28fcb673-98fe-4480-834d-f5f13367a681" />

