### PR TITLE
fix(header): move accredited statistics logo to fix focus order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fixed focus order of accredited statistics logo to meet WCAG visual flow standards [619](https://github.com/epimorphics/ukhpi/issues/619)
 - Fixed phone number and contact form links on the landing page by using symantic html[#618](https://github.com/epimorphics/ukhpi/issues/618).
 
 ## [2.3.3] - 2026-07-14

--- a/app/views/common/_header.html.haml
+++ b/app/views/common/_header.html.haml
@@ -5,7 +5,6 @@
         = link_to(root_path(lang: I18n.locale), class: 'content', title: t('common.header.home_link')) do
           = vite_image_tag('images/ukhpi-icon.png', srcset: vite_asset_path('images/ukhpi-icon.svg'), alt: 'UKHPI Logo')
 
-    = render partial: 'common/accredited_statistic_logo'
     .header-proposition
       .content
         = link_to(t('common.header.menu_text'), '#proposition-links', class: 'menu sr-only')
@@ -26,7 +25,7 @@
             %li
               = link_to(t('action.changelog'), changelog_index_path(lang: I18n.locale), class: active_class(changelog_index_path))
 
-
+    = render partial: 'common/accredited_statistic_logo'
 
 .o-lr-top-bar
 


### PR DESCRIPTION
Fixed focus order of accredited statistics logo to meet WCAG visual flow standards

relates to this ticket https://github.com/epimorphics/ukhpi/issues/619